### PR TITLE
chore: add GitHub Actions CI/CD pipeline

### DIFF
--- a/.bandit
+++ b/.bandit
@@ -1,0 +1,8 @@
+exclude_dirs:
+  - /tests
+  - /.venv
+
+skips:
+  - B101
+  - B104
+  - B311

--- a/.github/workflows/ci-develop.yml
+++ b/.github/workflows/ci-develop.yml
@@ -1,0 +1,311 @@
+name: Develop/Main CI
+
+on:
+  push:
+    branches: [main, develop]
+
+jobs:
+  comprehensive-tests:
+    name: Full test suite (Python ${{ matrix.python-version }} on ${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Run linting
+        run: uv run ruff check .
+
+      - name: Run type checking
+        run: uv run pyright
+
+      - name: Run tests with coverage
+        run: uv run pytest --cov=mock_api --cov-report=xml --cov-report=term-missing
+
+      - name: Upload coverage to Codecov
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12'
+        uses: codecov/codecov-action@v4
+        with:
+          files: ./coverage.xml
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+  package-build:
+    name: Package build verification
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Build package
+        run: uv build
+
+      - name: Check package metadata
+        run: |
+          uv run pip install twine
+          uv run twine check dist/*
+
+      - name: Test package installation
+        run: |
+          python -m venv test-env
+          source test-env/bin/activate || test-env\\Scripts\\activate
+          pip install dist/*.whl
+          mock-api --version
+          deactivate
+
+      - name: Store build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: package-distributions
+          path: dist/
+
+  end-to-end-tests:
+    name: End-to-end server tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Create test models file
+        run: |
+          cat > test_models.py << 'EOF'
+          from pydantic import BaseModel
+          from datetime import datetime
+
+          class User(BaseModel):
+              id: int
+              name: str
+              email: str
+              created_at: datetime
+
+          class Post(BaseModel):
+              id: int
+              title: str
+              content: str
+              author_id: int
+          EOF
+
+      - name: Start mock API server
+        run: |
+          uv run mock-api run test_models.py --port 3000 --seed 10 &
+          echo $! > server.pid
+          sleep 5
+
+      - name: Test API endpoints
+        run: |
+          # Test list users
+          curl -f http://localhost:3000/users || exit 1
+
+          # Test get single user
+          curl -f http://localhost:3000/users/1 || exit 1
+
+          # Test create user
+          curl -f -X POST http://localhost:3000/users \
+            -H "Content-Type: application/json" \
+            -d '{"id": 999, "name": "Test User", "email": "test@example.com", \
+            "created_at": "2025-01-01T00:00:00Z"}' || exit 1
+
+          # Test list posts
+          curl -f http://localhost:3000/posts || exit 1
+
+          # Test filtering
+          curl -f "http://localhost:3000/posts?author_id=1" || exit 1
+
+      - name: Stop server
+        if: always()
+        run: |
+          if [ -f server.pid ]; then
+            kill $(cat server.pid) || true
+          fi
+
+  performance-benchmarks:
+    name: Performance benchmarks
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Install performance testing tools
+        run: uv pip install pytest-benchmark memory-profiler
+
+      - name: Run performance benchmarks
+        run: |
+          # Create benchmark test file
+          cat > test_benchmarks.py << 'EOF'
+          import pytest
+          from mock_api.core.parser import ModelParser
+          from mock_api.core.generator import DataGenerator
+          from pydantic import BaseModel
+
+          class TestModel(BaseModel):
+              id: int
+              name: str
+              email: str
+
+          @pytest.mark.benchmark
+          def test_parser_performance(benchmark):
+              parser = ModelParser()
+              result = benchmark(parser.parse_file, "test_models.py")
+              assert len(result) > 0
+
+          @pytest.mark.benchmark
+          def test_generator_performance(benchmark):
+              generator = DataGenerator()
+              result = benchmark(generator.generate, TestModel, count=100)
+              assert len(result) == 100
+          EOF
+
+          # Run benchmarks if tests exist
+          if [ -f test_benchmarks.py ]; then
+            uv run pytest test_benchmarks.py -v --benchmark-only || echo "Benchmarks skipped"
+          fi
+
+  security-full:
+    name: Full security scan
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Run bandit security checks
+        run: uv run bandit -c .bandit -r mock_api -f json -o bandit-report.json || true
+
+      - name: Run pip-audit for vulnerabilities
+        run: uv run pip-audit --desc --format json --output pip-audit-report.json || true
+
+      - name: Upload security reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: security-reports
+          path: |
+            bandit-report.json
+            pip-audit-report.json
+
+  code-quality:
+    name: Code quality metrics
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Install quality tools
+        run: uv pip install radon
+
+      - name: Check code complexity
+        run: |
+          echo "=== Cyclomatic Complexity ==="
+          uv run radon cc mock_api -a -nb
+
+          echo "=== Maintainability Index ==="
+          uv run radon mi mock_api -nb
+
+      - name: Check code metrics
+        run: |
+          echo "=== Raw Metrics ==="
+          uv run radon raw mock_api -s
+
+  test-pypi-publish:
+    name: Test PyPI publish (main only)
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    needs: [comprehensive-tests, package-build]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Build package
+        run: uv build
+
+      - name: Publish to Test PyPI
+        continue-on-error: true
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          skip-existing: true
+          verbose: true

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -1,0 +1,77 @@
+name: PR CI
+
+on:
+  pull_request:
+    branches: [main, develop]
+
+jobs:
+  quick-checks:
+    name: Quick checks (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Run linting
+        run: uv run ruff check .
+
+      - name: Run formatting check
+        run: uv run ruff format --check .
+
+      - name: Run type checking
+        run: uv run pyright
+
+      - name: Run unit tests (fast)
+        run: uv run pytest --no-cov -q
+
+  yaml-lint:
+    name: YAML lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run yamllint
+        run: |
+          pip install yamllint
+          yamllint .github/workflows/
+
+  security:
+    name: Security checks
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Run bandit security checks
+        run: uv run bandit -c .bandit -r mock_api

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,82 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Build package
+        run: uv build
+
+      - name: Store the distribution packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+  publish-to-pypi:
+    name: Publish to PyPI
+    needs: [build]
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/mock-api
+
+    steps:
+      - name: Download all the dists
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Publish distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+  github-release:
+    name: Create GitHub Release
+    needs: [publish-to-pypi]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract version from tag
+        id: get_version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+
+      - name: Download all the dists
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Create GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: >-
+          gh release create
+          '${{ github.ref_name }}'
+          --repo '${{ github.repository }}'
+          --title 'Release ${{ github.ref_name }}'
+          --generate-notes
+          dist/**

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,6 +21,13 @@ repos:
       - id: check-merge-conflict
       - id: mixed-line-ending
 
+  # YAML linting
+  - repo: https://github.com/adrienverge/yamllint
+    rev: v1.35.1
+    hooks:
+      - id: yamllint
+        args: [--strict]
+
   # Pyproject formatting
   - repo: https://github.com/tox-dev/pyproject-fmt
     rev: "v2.5.0"

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,10 @@
+extends: default
+
+rules:
+  line-length:
+    max: 120
+    level: warning
+  document-start:
+    present: false
+  truthy:
+    allowed-values: ['true', 'false', 'on', 'off']

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,6 +132,119 @@ git push origin feat/ss/1-add-config
 
 7. After PR approval and merge, delete your feature branch
 
+### Release Workflow
+
+Releases are handled by maintainers. When ready to release a new version:
+
+1. **Create release branch** off `develop`:
+```bash
+git checkout develop
+git pull origin develop
+git checkout -b release/vX.Y.Z
+```
+
+2. **Rebase on main** to ensure a clean history:
+```bash
+git fetch origin main
+git rebase origin/main
+```
+
+3. **Create PR to main**:
+```bash
+gh pr create --base main --head release/vX.Y.Z \
+  --title "Release vX.Y.Z" \
+  --body "Release vX.Y.Z"
+```
+
+4. **Merge using merge commit** (not squash):
+```bash
+gh pr merge --merge
+```
+
+5. **Tag the release** after merge:
+```bash
+git checkout main
+git pull origin main
+git tag -a vX.Y.Z -m "Release vX.Y.Z"
+git push origin vX.Y.Z
+```
+
+6. **Merge back to develop**:
+```bash
+git checkout develop
+git pull origin develop
+git merge main
+git push origin develop
+```
+
+7. **Delete release branch**:
+```bash
+git branch -d release/vX.Y.Z
+git push origin --delete release/vX.Y.Z
+```
+
+**Note**: Pushing a tag automatically triggers PyPI release via GitHub Actions.
+
+### Tagging Strategy
+
+We follow **semantic versioning** with **PEP 440** pre-release format:
+
+**Format**: `vMAJOR.MINOR.PATCH[{a|b|rc}N]`
+
+**Version Components**:
+- **MAJOR**: Breaking changes (incompatible API changes)
+- **MINOR**: New features (backwards compatible)
+- **PATCH**: Bug fixes (backwards compatible)
+
+**Pre-release Identifiers** (PEP 440):
+- **aN**: Alpha releases (early development, unstable)
+- **bN**: Beta releases (feature complete, testing phase)
+- **rcN**: Release candidates (final testing before stable)
+
+**Examples**:
+```bash
+# Alpha releases (early development)
+v0.1.0a1
+v0.1.0a2
+v0.1.0a3
+
+# Beta releases (feature complete, testing)
+v0.1.0b1
+v0.1.0b2
+
+# Release candidates (final testing)
+v0.1.0rc1
+v0.1.0rc2
+
+# Stable release
+v0.1.0
+
+# Patch releases
+v0.1.1
+v0.1.2
+
+# Minor releases with pre-releases
+v0.2.0a1  # Alpha for v0.2.0
+v0.2.0b1  # Beta for v0.2.0
+v0.2.0rc1 # RC for v0.2.0
+v0.2.0    # Stable v0.2.0
+
+# Major releases
+v1.0.0rc1 # RC for v1.0.0
+v1.0.0    # Stable v1.0.0
+```
+
+**Release Types**:
+- **Patch** (X.Y.Z → X.Y.Z+1): Bug fixes, documentation
+- **Minor** (X.Y.Z → X.Y+1.0): New features, backwards compatible
+- **Major** (X.Y.Z → X+1.0.0): Breaking changes
+
+**Release Process**:
+- All tags are created on the `main` branch after merging
+- Pushing a tag automatically triggers PyPI release
+- Pre-releases (a, b, rc) are published to PyPI as pre-releases
+- Stable releases have no pre-release identifier
+
 ### Commit Messages
 
 Follow the conventional commits format:


### PR DESCRIPTION
## Summary
- Add ci-pr.yml for fast PR feedback
- Add ci-develop.yml for comprehensive checks on develop/main
- Add release.yml for automated PyPI releases on tag push
- Add yamllint to GitHub Actions and pre-commit hooks
- Update CONTRIBUTING.md with release workflow and PEP 440 tagging strategy

## Details
Created a three-tier CI/CD pipeline:

**PR CI (Fast):** Linting, type checking, unit tests, security, YAML lint
**Develop/Main CI (Comprehensive):** Full test matrix, package build verification, E2E tests, performance benchmarks, security scans, code quality metrics
**Release:** Automated PyPI publishing on tag push with GitHub releases

Closes #14