### PR TITLE
feat: add comprehensive performance benchmarks (#23)

### DIFF
--- a/.github/workflows/ci-develop.yml
+++ b/.github/workflows/ci-develop.yml
@@ -167,6 +167,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -181,40 +183,57 @@ jobs:
       - name: Install dependencies
         run: uv sync --all-extras
 
-      - name: Install performance testing tools
-        run: uv pip install pytest-benchmark memory-profiler
+      - name: Download previous benchmark results
+        uses: actions/cache@v4
+        with:
+          path: .benchmarks
+          key: benchmark-results-${{ github.ref_name }}
+          restore-keys: |
+            benchmark-results-develop
+            benchmark-results-
 
-      - name: Run performance benchmarks
+      - name: Run benchmarks
         run: |
-          # Create benchmark test file
-          cat > test_benchmarks.py << 'EOF'
-          import pytest
-          from mock_api.core.parser import ModelParser
-          from mock_api.core.generator import DataGenerator
-          from pydantic import BaseModel
+          uv run pytest tests/benchmarks/ \
+            --benchmark-only \
+            --benchmark-json=benchmark-results.json \
+            --benchmark-autosave \
+            --benchmark-save-data \
+            --benchmark-compare \
+            --benchmark-compare-fail=mean:20% \
+            -v
 
-          class TestModel(BaseModel):
-              id: int
-              name: str
-              email: str
+      - name: Store benchmark results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-results-${{ github.sha }}
+          path: |
+            benchmark-results.json
+            .benchmarks/
+          retention-days: 90
 
-          @pytest.mark.benchmark
-          def test_parser_performance(benchmark):
-              parser = ModelParser()
-              result = benchmark(parser.parse_file, "test_models.py")
-              assert len(result) > 0
+      - name: Comment benchmark results on commit
+        if: github.event_name == 'push'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const data = JSON.parse(fs.readFileSync('benchmark-results.json', 'utf8'));
 
-          @pytest.mark.benchmark
-          def test_generator_performance(benchmark):
-              generator = DataGenerator()
-              result = benchmark(generator.generate, TestModel, count=100)
-              assert len(result) == 100
-          EOF
+            const benchmarks = data.benchmarks.map(b =>
+              `| ${b.name} | ${(b.stats.mean * 1000).toFixed(2)}ms | ${(b.stats.stddev * 1000).toFixed(2)}ms |`
+            ).join('\n');
 
-          # Run benchmarks if tests exist
-          if [ -f test_benchmarks.py ]; then
-            uv run pytest test_benchmarks.py -v --benchmark-only || echo "Benchmarks skipped"
-          fi
+            const body = `## Benchmark Results\n\n| Benchmark | Mean | Std Dev |\n` +
+              `|-----------|------|---------|\\n${benchmarks}`;
+
+            github.rest.repos.createCommitComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              commit_sha: context.sha,
+              body: body
+            });
 
   security-full:
     name: Full security scan

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ coverage.xml
 htmlcov/
 .tox/
 .nox/
+.benchmarks/
 
 # Type checking
 .mypy_cache/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -76,13 +76,3 @@ repos:
           - fastapi>=0.115.0
           - faker>=30.0.0
         stages: [manual]
-
-  # Fast tests before commit
-  - repo: local
-    hooks:
-      - id: test-fast
-        name: Run fast tests
-        entry: make test-fast
-        language: system
-        pass_filenames: false
-        always_run: true

--- a/Makefile
+++ b/Makefile
@@ -212,7 +212,20 @@ deps: ## Show dependency tree
 
 benchmark: ## Run performance benchmarks
 	@echo "$(BLUE)Running benchmarks...$(NC)"
-	@echo "$(YELLOW)⚠ Benchmark suite not configured yet$(NC)"
+	uv run pytest tests/benchmarks/ --benchmark-only -v
+
+benchmark-compare: ## Run benchmarks with comparison to baseline
+	@echo "$(BLUE)Running benchmarks with comparison...$(NC)"
+	uv run pytest tests/benchmarks/ --benchmark-only --benchmark-compare -v
+
+benchmark-save: ## Run benchmarks and save as new baseline
+	@echo "$(BLUE)Running benchmarks and saving baseline...$(NC)"
+	uv run pytest tests/benchmarks/ --benchmark-only --benchmark-autosave -v
+
+benchmark-report: ## Generate benchmark histogram report
+	@echo "$(BLUE)Generating benchmark report...$(NC)"
+	uv run pytest tests/benchmarks/ --benchmark-only --benchmark-histogram -v
+	@echo "$(GREEN)Report saved to .benchmarks/$(NC)"
 
 ##@ Examples
 

--- a/mock_api/core/server.py
+++ b/mock_api/core/server.py
@@ -145,12 +145,12 @@ class Server:
         # Optionally pre-populate with generated data
         if self.generate_data:
             logger.info(f"Pre-populating data ({self.data_count} per model)")
-            self._populate_data()
+            self.populate_data()
 
         self._app = app
         return app
 
-    def _populate_data(self) -> None:
+    def populate_data(self) -> None:
         """Pre-populate store with generated data.
 
         Uses DataGenerator to create realistic test data for all models.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,15 +1,15 @@
 [build-system]
 build-backend = "hatchling.build"
-requires = ["hatchling"]
+requires = [ "hatchling" ]
 
 [project]
 name = "mock-api"
 version = "0.1.0"
 description = "Generate full-featured REST APIs from Pydantic models or TypeScript types"
 readme = "README.md"
-keywords = ["api", "mock", "testing", "pydantic", "fastapi", "rest", "fake-data"]
+keywords = [ "api", "fake-data", "fastapi", "mock", "pydantic", "rest", "testing" ]
 license = { text = "MIT" }
-authors = [{ name = "Sudarshan Satyendra Sagar", email = "your.email@example.com" }]
+authors = [ { name = "Sudarshan Satyendra Sagar", email = "your.email@example.com" } ]
 requires-python = ">=3.11"
 classifiers = [
   "Development Status :: 3 - Alpha",
@@ -24,38 +24,35 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
-  "fastapi>=0.115.0",
-  "uvicorn[standard]>=0.30.0",
-  "pydantic>=2.0.0",
-  "faker>=30.0.0",
-  "click>=8.1.0",
-  "rich>=13.0.0",
+  "click>=8.1",
+  "faker>=30",
+  "fastapi>=0.115",
+  "pydantic>=2",
+  "rich>=13",
+  "uvicorn[standard]>=0.30",
 ]
 
-[project.optional-dependencies]
-dev = [
+optional-dependencies.dev = [
   "bandit>=1.7",
+  "httpx>=0.27",
+  "memory-profiler>=0.61",
   "pip-audit>=2.7",
   "pre-commit>=3",
   "pyright>=1.1.350",
   "pytest>=8",
+  "pytest-asyncio>=0.24",
+  "pytest-benchmark>=4",
   "pytest-cov>=4",
-  "pytest-asyncio>=0.24.0",
-  "httpx>=0.27.0",
   "ruff>=0.8",
 ]
-
-[project.urls]
-Homepage = "https://github.com/sudzxd/mock-api"
-Documentation = "https://github.com/sudzxd/mock-api#readme"
-Repository = "https://github.com/sudzxd/mock-api"
-Issues = "https://github.com/sudzxd/mock-api/issues"
-
-[project.scripts]
-mock-api = "mock_api.cli.main:cli"
+urls.Documentation = "https://github.com/sudzxd/mock-api#readme"
+urls.Homepage = "https://github.com/sudzxd/mock-api"
+urls.Issues = "https://github.com/sudzxd/mock-api/issues"
+urls.Repository = "https://github.com/sudzxd/mock-api"
+scripts.mock-api = "mock_api.cli.main:cli"
 
 [tool.hatch.build.targets.wheel]
-packages = ["mock_api"]
+packages = [ "mock_api" ]
 
 # ==============================================================================
 # Ruff Configuration (Linting + Formatting)
@@ -64,97 +61,62 @@ packages = ["mock_api"]
 [tool.ruff]
 target-version = "py311"
 line-length = 88
-src = ["mock_api", "tests", "examples"]
+src = [ "examples", "mock_api", "tests" ]
 
-[tool.ruff.lint]
-select = [
-  "ARG",  # flake8-unused-arguments
-  "B",    # flake8-bugbear
-  "C4",   # flake8-comprehensions
-  "E",    # pycodestyle errors (includes E501 line-too-long)
-  "F",    # pyflakes
-  "I",    # isort
-  "PTH",  # flake8-use-pathlib
-  "RET",  # flake8-return
-  "SIM",  # flake8-simplify
-  "TRY",  # tryceratops
-  "UP",   # pyupgrade
-  "W",    # pycodestyle warnings
+lint.select = [
+  "ARG", # flake8-unused-arguments
+  "B",   # flake8-bugbear
+  "C4",  # flake8-comprehensions
+  "E",   # pycodestyle errors (includes E501 line-too-long)
+  "F",   # pyflakes
+  "I",   # isort
+  "PTH", # flake8-use-pathlib
+  "RET", # flake8-return
+  "SIM", # flake8-simplify
+  "TRY", # tryceratops
+  "UP",  # pyupgrade
+  "W",   # pycodestyle warnings
 ]
-ignore = [
-  "TRY003",  # Avoid specifying long messages outside exception class
+lint.ignore = [
+  "TRY003", # Avoid specifying long messages outside exception class
 ]
-
-[tool.ruff.lint.per-file-ignores]
-"tests/**/*.py" = [
-  "ARG",   # Allow unused arguments in tests
-  "S101",  # Allow assert in tests
+lint.per-file-ignores."tests/**/*.py" = [
+  "ARG",  # Allow unused arguments in tests
+  "S101", # Allow assert in tests
 ]
-
-[tool.ruff.lint.pycodestyle]
-max-line-length = 88
-
 # ==============================================================================
 # Pyright Configuration (Type Checking)
 # ==============================================================================
-
-[tool.pyright]
-pythonVersion = "3.11"
-typeCheckingMode = "strict"
-include = ["mock_api", "tests", "examples"]
-exclude = ["**/__pycache__", "build", "dist", ".venv"]
-
-# Strict mode settings
-reportMissingImports = true
-reportMissingTypeStubs = true
-reportUnusedImport = true
-reportUnusedClass = true
-reportUnusedFunction = true
-reportUnusedVariable = true
-reportDuplicateImport = true
-reportPrivateUsage = true
-reportConstantRedefinition = true
-reportIncompatibleMethodOverride = true
-reportIncompatibleVariableOverride = true
-reportInconsistentConstructor = true
-reportUnnecessaryIsInstance = true
-reportUnnecessaryCast = true
-reportUnnecessaryComparison = true
-reportUnnecessaryContains = true
-reportUnusedCallResult = false
-reportUnknownMemberType = true
-
-# ==============================================================================
-# Pytest Configuration
-# ==============================================================================
+lint.pycodestyle.max-line-length = 88
 
 [tool.pytest.ini_options]
-testpaths = ["tests"]
-python_files = ["test_*.py"]
-python_classes = ["Test*"]
-python_functions = ["test_*"]
+testpaths = [ "tests" ]
+python_files = [ "test_*.py" ]
+python_classes = [ "Test*" ]
+python_functions = [ "test_*" ]
 addopts = [
-  "-ra",                   # Show summary of all test outcomes
-  "-q",                    # Quiet mode
-  "--strict-markers",      # Strict marker usage
-  "--strict-config",       # Strict config
-  "--cov=mock_api",        # Coverage for our package
-  "--cov-report=term-missing",  # Show missing lines in terminal
-  "--cov-report=html",     # Generate HTML coverage report
-  "--cov-report=xml",      # Generate XML for CI
+  "-ra",                       # Show summary of all test outcomes
+  "-q",                        # Quiet mode
+  "--strict-markers",          # Strict marker usage
+  "--strict-config",           # Strict config
+  "--cov=mock_api",            # Coverage for our package
+  "--cov-report=term-missing", # Show missing lines in terminal
+  "--cov-report=html",         # Generate HTML coverage report
+  "--cov-report=xml",          # Generate XML for CI
 ]
 markers = [
   "unit: Unit tests",
   "integration: Integration tests",
   "slow: Slow tests",
+  "benchmark: Performance benchmark tests",
 ]
 
 # ==============================================================================
-# Coverage Configuration
+# Pytest-Benchmark Configuration
 # ==============================================================================
 
 [tool.coverage.run]
-source = ["mock_api"]
+source = [ "mock_api" ]
 branch = true
 omit = [
   "*/tests/*",
@@ -180,6 +142,56 @@ directory = "htmlcov"
 # Bandit Configuration (Security)
 # ==============================================================================
 
+[tool.pyright]
+pythonVersion = "3.11"
+typeCheckingMode = "strict"
+include = [ "mock_api", "tests", "examples" ]
+exclude = [ "**/__pycache__", "build", "dist", ".venv" ]
+
+# Strict mode settings
+reportMissingImports = true
+reportMissingTypeStubs = true
+reportUnusedImport = true
+reportUnusedClass = true
+reportUnusedFunction = true
+reportUnusedVariable = true
+reportDuplicateImport = true
+reportPrivateUsage = true
+reportConstantRedefinition = true
+reportIncompatibleMethodOverride = true
+reportIncompatibleVariableOverride = true
+reportInconsistentConstructor = true
+reportUnnecessaryIsInstance = true
+reportUnnecessaryCast = true
+reportUnnecessaryComparison = true
+reportUnnecessaryContains = true
+reportUnusedCallResult = false
+reportUnknownMemberType = true
+
+# ==============================================================================
+# Pytest Configuration
+# ==============================================================================
+
+[tool.pytest-benchmark]
+warmup = true
+warmup_iterations = 5
+calibration_precision = 10
+max_time = 1.0
+statistics = [ "min", "max", "mean", "stddev", "median", "iqr", "outliers", "rounds" ]
+histogram = true
+compare = "mean"
+compare_fail = [ "mean:20%" ]
+autosave = true
+save_data = true
+storage = "file://.benchmarks"
+verbose = true
+columns = [ "min", "max", "mean", "stddev", "median", "rounds" ]
+sort = "mean"
+
+# ==============================================================================
+# Coverage Configuration
+# ==============================================================================
+
 [tool.bandit]
-exclude_dirs = ["tests", ".venv"]
-skips = ["B101"]  # Allow assert in non-test code for type narrowing
+exclude_dirs = [ "tests", ".venv" ]
+skips = [ "B101" ]                  # Allow assert in non-test code for type narrowing

--- a/tests/benchmarks/__init__.py
+++ b/tests/benchmarks/__init__.py
@@ -1,0 +1,5 @@
+"""Performance benchmark tests for mock-api.
+
+This package contains benchmark tests for measuring and tracking performance
+of core components including Parser, Generator, Store, Router, and Server.
+"""

--- a/tests/benchmarks/conftest.py
+++ b/tests/benchmarks/conftest.py
@@ -1,0 +1,221 @@
+"""Pytest fixtures for benchmark tests.
+
+This module provides shared fixtures for all benchmark tests including:
+- Pre-populated data stores
+- Parsed schema instances
+- Test clients
+- Benchmark models
+"""
+
+from __future__ import annotations
+
+# =============================================================================
+# IMPORTS
+# =============================================================================
+# Standard library
+from pathlib import Path
+
+# Third-party
+import pytest
+from fastapi.testclient import TestClient
+from mock_api.core.generator import DataGenerator
+from mock_api.core.parser import SchemaParser
+from mock_api.core.router import RouterGenerator
+from mock_api.core.server import Server
+from mock_api.core.store import DataStore
+
+# Project/Local
+from mock_api.core.types import ModelSchema
+from pydantic import BaseModel
+
+# =============================================================================
+# PATH FIXTURES
+# =============================================================================
+
+
+@pytest.fixture(scope="session")
+def benchmark_fixtures_dir() -> Path:
+    """Path to benchmark fixture models directory."""
+    return Path(__file__).parent.parent / "fixtures"
+
+
+@pytest.fixture(scope="session")
+def benchmark_models_path(benchmark_fixtures_dir: Path) -> Path:
+    """Path to benchmark_models.py file."""
+    return benchmark_fixtures_dir / "benchmark_models.py"
+
+
+# =============================================================================
+# PARSER FIXTURES
+# =============================================================================
+
+
+@pytest.fixture
+def parser() -> SchemaParser:
+    """Create a fresh SchemaParser instance."""
+    return SchemaParser()
+
+
+@pytest.fixture(scope="session")
+def parsed_benchmark_schema(benchmark_models_path: str) -> dict[str, ModelSchema]:
+    """Parse benchmark models once per session."""
+    parser = SchemaParser()
+    return parser.parse_file(benchmark_models_path)
+
+
+# =============================================================================
+# GENERATOR FIXTURES
+# =============================================================================
+
+
+@pytest.fixture
+def generator(parsed_benchmark_schema: dict[str, ModelSchema]) -> DataGenerator:
+    """Create a fresh DataGenerator instance."""
+    return DataGenerator(schemas=parsed_benchmark_schema)
+
+
+@pytest.fixture
+def seeded_generator(parsed_benchmark_schema: dict[str, ModelSchema]) -> DataGenerator:
+    """Create a DataGenerator with fixed seed for reproducibility."""
+    return DataGenerator(schemas=parsed_benchmark_schema, seed=42)
+
+
+# =============================================================================
+# STORE FIXTURES
+# =============================================================================
+
+
+@pytest.fixture
+def empty_store() -> DataStore:
+    """Create an empty DataStore instance."""
+    return DataStore()
+
+
+@pytest.fixture
+def small_populated_store() -> DataStore:
+    """DataStore pre-populated with 10 simple instances."""
+    store = DataStore()
+    data = {
+        "Contact": [
+            {
+                "id": i,
+                "name": f"Person {i}",
+                "email": f"person{i}@example.com",
+                "phone": f"+1-555-000-{i:04d}",
+            }
+            for i in range(1, 11)
+        ]
+    }
+    store.load(data)
+    return store
+
+
+@pytest.fixture
+def medium_populated_store() -> DataStore:
+    """DataStore pre-populated with 100 simple instances."""
+    store = DataStore()
+    data = {
+        "Contact": [
+            {
+                "id": i,
+                "name": f"Person {i}",
+                "email": f"person{i}@example.com",
+                "phone": f"+1-555-000-{i:04d}",
+            }
+            for i in range(1, 101)
+        ]
+    }
+    store.load(data)
+    return store
+
+
+@pytest.fixture
+def large_populated_store() -> DataStore:
+    """DataStore pre-populated with 1000 simple instances."""
+    store = DataStore()
+    data = {
+        "Contact": [
+            {
+                "id": i,
+                "name": f"Person {i}",
+                "email": f"person{i}@example.com",
+                "phone": f"+1-555-000-{i:04d}",
+            }
+            for i in range(1, 1001)
+        ]
+    }
+    store.load(data)
+    return store
+
+
+# =============================================================================
+# ROUTER FIXTURES
+# =============================================================================
+
+
+@pytest.fixture
+def router_generator() -> RouterGenerator:
+    """Create a fresh RouterGenerator instance."""
+    return RouterGenerator(schemas={}, store=DataStore(), prefix="/api/v1")
+
+
+# =============================================================================
+# SERVER & CLIENT FIXTURES
+# =============================================================================
+
+
+@pytest.fixture
+def benchmark_test_client(
+    parsed_benchmark_schema: dict[str, type[BaseModel]],
+) -> TestClient:
+    """Create a TestClient with benchmark models loaded."""
+    server = Server(
+        models_file="",
+        generate_data=True,
+        data_count=10,
+    )
+    app = server.create_app()
+    return TestClient(app)
+
+
+@pytest.fixture
+def empty_test_client(
+    parsed_benchmark_schema: dict[str, type[BaseModel]],
+) -> TestClient:
+    """Create a TestClient with benchmark models but no pre-populated data."""
+    server = Server(
+        models_file="",
+        generate_data=False,
+    )
+    app = server.create_app()
+    return TestClient(app)
+
+
+# =============================================================================
+# DATA FIXTURES
+# =============================================================================
+
+
+@pytest.fixture
+def sample_contact_data() -> dict[str, str | int]:
+    """Sample contact data for create/update operations."""
+    return {
+        "id": 999,
+        "name": "Test Contact",
+        "email": "test@example.com",
+        "phone": "+1-555-999-9999",
+    }
+
+
+@pytest.fixture
+def batch_contact_data() -> list[dict[str, str | int]]:
+    """Batch of contact data for bulk operations (100 items)."""
+    return [
+        {
+            "id": 1000 + i,
+            "name": f"Batch Contact {i}",
+            "email": f"batch{i}@example.com",
+            "phone": f"+1-555-999-{i:04d}",
+        }
+        for i in range(100)
+    ]

--- a/tests/benchmarks/test_generator_benchmarks.py
+++ b/tests/benchmarks/test_generator_benchmarks.py
@@ -1,0 +1,279 @@
+"""Benchmark tests for DataGenerator performance.
+
+Tests generator performance across various scenarios:
+- Different batch sizes (10, 100, 1000)
+- Different field types and complexities
+- Foreign key resolution and caching
+- Reproducible seeded generation
+- Dependency ordering for FK models
+
+Performance targets:
+- 10 instances: < 50ms
+- 100 instances: < 200ms
+- 1000 instances: < 2s
+"""
+
+from __future__ import annotations
+
+# =============================================================================
+# IMPORTS
+# =============================================================================
+# Standard library
+from pathlib import Path
+
+# Third-party
+import pytest
+from mock_api.core.generator import DataGenerator
+from pytest_benchmark.fixture import BenchmarkFixture
+
+# =============================================================================
+# TESTS: Generator Scaling
+# =============================================================================
+
+
+@pytest.mark.benchmark(group="generator-scale")
+def test_generator_small_batch(
+    benchmark: BenchmarkFixture,
+    generator: DataGenerator,
+) -> None:
+    """Benchmark generating 10 Contact instances.
+
+    Performance target: < 50ms
+    Baseline for simple 4-field model.
+    """
+
+    def generate() -> None:
+        generator.generate("Contact", count=10)
+
+    benchmark(generate)
+
+
+@pytest.mark.benchmark(group="generator-scale")
+def test_generator_medium_batch(
+    benchmark: BenchmarkFixture,
+    generator: DataGenerator,
+) -> None:
+    """Benchmark generating 100 Contact instances.
+
+    Performance target: < 200ms
+    Tests linear scaling with count.
+
+    Args:
+        benchmark: Benchmark fixture.
+        generator: DataGenerator instance.
+        parsed_benchmark_schema: Parsed model schemas.
+    """
+
+    def generate() -> None:
+        generator.generate("Contact", count=100)
+
+    benchmark(generate)
+
+
+@pytest.mark.benchmark(group="generator-scale")
+def test_generator_large_batch(
+    benchmark: BenchmarkFixture,
+    generator: DataGenerator,
+) -> None:
+    """Benchmark generating 1000 Contact instances.
+
+    Performance target: < 2s
+    Tests Faker and deepcopy overhead at scale.
+    """
+
+    def generate() -> None:
+        generator.generate("Contact", count=1000)
+
+    benchmark(generate)
+
+
+# =============================================================================
+# TESTS: Generator Field Types
+# =============================================================================
+
+
+@pytest.mark.benchmark(group="generator-field-types")
+def test_generator_simple_fields(
+    benchmark: BenchmarkFixture,
+    generator: DataGenerator,
+) -> None:
+    """Benchmark generating Contact (str, int fields).
+
+    Performance target: < 30ms for 10 instances
+    """
+
+    def generate() -> None:
+        generator.generate("Contact", count=10)
+
+    benchmark(generate)
+
+
+@pytest.mark.benchmark(group="generator-field-types")
+def test_generator_complex_fields(
+    benchmark: BenchmarkFixture,
+    generator: DataGenerator,
+) -> None:
+    """Benchmark generating ComplexModel (enums, datetime, optional fields).
+
+    Performance target: < 80ms for 10 instances
+    Tests overhead of complex field types.
+    """
+
+    def generate() -> None:
+        generator.generate("ComplexModel", count=10)
+
+    benchmark(generate)
+
+
+@pytest.mark.benchmark(group="generator-field-types")
+def test_generator_large_field_count(
+    benchmark: BenchmarkFixture,
+    generator: DataGenerator,
+) -> None:
+    """Benchmark generating LargeModel (20 fields).
+
+    Performance target: < 150ms for 10 instances
+    Tests O(fields) scaling.
+    """
+
+    def generate() -> None:
+        generator.generate("LargeModel", count=10)
+
+    benchmark(generate)
+
+
+# =============================================================================
+# TESTS: Generator Foreign Key Resolution
+# =============================================================================
+
+
+@pytest.mark.benchmark(group="generator-fk")
+def test_generator_foreign_key_simple(
+    benchmark: BenchmarkFixture,
+    generator: DataGenerator,
+) -> None:
+    """Benchmark generating Book (1 FK to Author).
+
+    Performance target: < 60ms for 10 instances
+    Tests FK resolution overhead.
+    """
+    # First generate authors so FK references are valid
+    generator.generate("Author", count=20)
+
+    def generate() -> None:
+        generator.generate("Book", count=10)
+
+    benchmark(generate)
+
+
+@pytest.mark.benchmark(group="generator-fk")
+def test_generator_foreign_key_multiple(
+    benchmark: BenchmarkFixture,
+    generator: DataGenerator,
+) -> None:
+    """Benchmark generating Review (2 FKs: book_id, author_id).
+
+    Performance target: < 80ms for 10 instances
+    Tests multi-FK overhead.
+    """
+    # Generate related data so FK references are valid
+    generator.generate("Author", count=20)
+    generator.generate("Book", count=50)
+
+    def generate() -> None:
+        generator.generate("Review", count=10)
+
+    benchmark(generate)
+
+
+# =============================================================================
+# TESTS: Generator Reproducibility
+# =============================================================================
+
+
+@pytest.mark.benchmark(group="generator-reproducibility")
+def test_generator_seeded_generation(
+    benchmark: BenchmarkFixture,
+    seeded_generator: DataGenerator,
+) -> None:
+    """Benchmark seeded generation for reproducibility.
+
+    Performance target: < 60ms for 10 instances
+    Should be comparable to non-seeded generation.
+    """
+
+    def generate() -> None:
+        seeded_generator.generate("Contact", count=10)
+
+    benchmark(generate)
+
+
+# =============================================================================
+# TESTS: Generator Dependency Ordering
+# =============================================================================
+
+
+@pytest.mark.benchmark(group="generator-dependency")
+def test_generator_dependency_ordering(
+    benchmark: BenchmarkFixture,
+    generator: DataGenerator,
+    benchmark_models_path: Path,
+) -> None:
+    """Benchmark generation with dependency ordering (Author -> Book -> Review).
+
+    Performance target: < 300ms for 10 of each model
+    Tests topological sort and cascading generation.
+    """
+
+    def generate_all() -> None:
+        generator.generate("Author", count=10)
+        generator.generate("Book", count=10)
+        generator.generate("Review", count=10)
+
+    benchmark(generate_all)
+
+
+# =============================================================================
+# TESTS: Generator Mixed Models
+# =============================================================================
+
+
+@pytest.mark.benchmark(group="generator-batch-mixed")
+def test_generator_mixed_models_batch(
+    benchmark: BenchmarkFixture,
+    generator: DataGenerator,
+) -> None:
+    """Benchmark generating batches of different model types.
+
+    Performance target: < 400ms
+    Tests generator reuse across different models.
+    """
+
+    def generate_mixed() -> None:
+        generator.generate("Contact", count=50)
+        generator.generate("ComplexModel", count=50)
+        generator.generate("Author", count=50)
+
+    benchmark(generate_mixed)
+
+
+# =============================================================================
+# TESTS: Generator Optional Fields
+# =============================================================================
+
+
+@pytest.mark.benchmark(group="generator-optional-fields")
+def test_generator_optional_fields(
+    benchmark: BenchmarkFixture,
+    generator: DataGenerator,
+) -> None:
+    """Benchmark generating models with optional fields (Author with bio).
+
+    Performance target: < 70ms for 10 instances
+    Tests 20% null probability logic overhead.
+    """
+
+    def generate() -> None:
+        generator.generate("Author", count=10)
+
+    benchmark(generate)

--- a/tests/benchmarks/test_parser_benchmarks.py
+++ b/tests/benchmarks/test_parser_benchmarks.py
@@ -1,0 +1,271 @@
+"""Benchmark tests for SchemaParser performance.
+
+Tests parser performance across various scenarios:
+- Simple vs complex models
+- Multiple model parsing
+- Field extraction at different scales
+- Foreign key relationship detection
+- Enum handling
+- Circular dependency detection
+
+Performance targets:
+- Simple model (5 fields): < 10ms
+- Complex model (20 fields, 5 FKs): < 50ms
+- Large file (20 models): < 200ms
+"""
+
+from __future__ import annotations
+
+# =============================================================================
+# IMPORTS
+# =============================================================================
+# Standard library
+# Third-party
+import pytest
+
+# Project/Local
+from mock_api.core.parser import SchemaParser
+from pytest_benchmark.fixture import BenchmarkFixture
+
+# =============================================================================
+# TESTS: Parser Basic Operations
+# =============================================================================
+
+
+@pytest.mark.benchmark(group="parser-basic")
+def test_parser_simple_model(
+    benchmark: BenchmarkFixture,
+    benchmark_models_path: str,
+) -> None:
+    """Benchmark parsing a simple 4-field model (Contact).
+
+    Performance target: < 10ms
+    """
+    parser = SchemaParser()
+
+    def parse() -> None:
+        parser.parse_file(benchmark_models_path)
+
+    benchmark(parse)
+
+
+@pytest.mark.benchmark(group="parser-basic")
+def test_parser_simple_model_cached(
+    benchmark: BenchmarkFixture,
+    benchmark_models_path: str,
+) -> None:
+    """Benchmark parsing with warm caches (2nd parse of same file).
+
+    Performance target: Should be faster than cold parse
+    """
+    parser = SchemaParser()
+    # Warm up the cache
+    parser.parse_file(benchmark_models_path)
+
+    def parse() -> None:
+        parser.parse_file(benchmark_models_path)
+
+    benchmark(parse)
+
+
+# =============================================================================
+# TESTS: Parser Field Extraction
+# =============================================================================
+
+
+@pytest.mark.benchmark(group="parser-field-extraction")
+def test_parser_field_extraction_contact(
+    benchmark: BenchmarkFixture,
+    parser: SchemaParser,
+    benchmark_models_path: str,
+) -> None:
+    """Benchmark field extraction from Contact model (4 fields).
+
+    Performance target: < 5ms
+    """
+    schemas = parser.parse_file(benchmark_models_path)
+    contact_model = schemas["Contact"]
+
+    def extract_fields() -> None:
+        assert contact_model.pydantic_model is not None
+        _ = contact_model.pydantic_model.model_fields
+
+    benchmark(extract_fields)
+
+
+@pytest.mark.benchmark(group="parser-field-extraction")
+def test_parser_field_extraction_complex(
+    benchmark: BenchmarkFixture,
+    parser: SchemaParser,
+    benchmark_models_path: str,
+) -> None:
+    """Benchmark field extraction from ComplexModel (9 fields with enums).
+
+    Performance target: < 10ms
+    """
+    schemas = parser.parse_file(benchmark_models_path)
+    complex_model = schemas["ComplexModel"]
+
+    def extract_fields() -> None:
+        assert complex_model.pydantic_model is not None
+        _ = complex_model.pydantic_model.model_fields
+
+    benchmark(extract_fields)
+
+
+@pytest.mark.benchmark(group="parser-field-extraction")
+def test_parser_field_extraction_large(
+    benchmark: BenchmarkFixture,
+    parser: SchemaParser,
+    benchmark_models_path: str,
+) -> None:
+    """Benchmark field extraction from LargeModel (20 fields).
+
+    Performance target: < 15ms
+    """
+    schemas = parser.parse_file(benchmark_models_path)
+    large_model = schemas["LargeModel"]
+
+    def extract_fields() -> None:
+        assert large_model.pydantic_model is not None
+        _ = large_model.pydantic_model.model_fields
+
+    benchmark(extract_fields)
+
+
+# =============================================================================
+# TESTS: Parser Relationship Detection
+# =============================================================================
+
+
+@pytest.mark.benchmark(group="parser-relationships")
+def test_parser_relationship_detection_simple(
+    benchmark: BenchmarkFixture,
+    benchmark_models_path: str,
+) -> None:
+    """Benchmark FK relationship detection for simple models (Author, Book).
+
+    Performance target: < 30ms
+    Tests the 4-pass relationship detection algorithm.
+    """
+    parser = SchemaParser()
+
+    def parse_with_fks() -> None:
+        schemas = parser.parse_file(benchmark_models_path)
+        # Verify FK was detected
+        assert "Book" in schemas
+        assert schemas["Book"].pydantic_model is not None
+        book_fields = schemas["Book"].pydantic_model.model_fields
+        assert "author_id" in book_fields
+
+    benchmark(parse_with_fks)
+
+
+@pytest.mark.benchmark(group="parser-relationships")
+def test_parser_relationship_detection_complex(
+    benchmark: BenchmarkFixture,
+    benchmark_models_path: str,
+) -> None:
+    """Benchmark FK detection for multi-FK model (Review with 2 FKs).
+
+    Performance target: < 40ms
+    Tests O(n*m) complexity of relationship detection.
+    """
+    parser = SchemaParser()
+
+    def parse_multi_fk() -> None:
+        schemas = parser.parse_file(benchmark_models_path)
+        # Review has 2 FKs: book_id and author_id
+        assert "Review" in schemas
+        assert schemas["Review"].pydantic_model is not None
+        review_fields = schemas["Review"].pydantic_model.model_fields
+        assert "book_id" in review_fields
+        assert "author_id" in review_fields
+
+    benchmark(parse_multi_fk)
+
+
+@pytest.mark.benchmark(group="parser-relationships")
+def test_parser_circular_dependency_detection(
+    benchmark: BenchmarkFixture,
+    benchmark_models_path: str,
+) -> None:
+    """Benchmark circular dependency handling (Category with self-referential FK).
+
+    Performance target: < 50ms
+    Tests cycle detection in relationship graph.
+    """
+    parser = SchemaParser()
+
+    def parse_circular() -> None:
+        schemas = parser.parse_file(benchmark_models_path)
+        # Category has parent_id which is self-referential
+        assert "Category" in schemas
+        assert schemas["Category"].pydantic_model is not None
+        category_fields = schemas["Category"].pydantic_model.model_fields
+        assert "parent_id" in category_fields
+
+    benchmark(parse_circular)
+
+
+# =============================================================================
+# TESTS: Parser Enum Handling
+# =============================================================================
+
+
+@pytest.mark.benchmark(group="parser-enum")
+def test_parser_enum_handling(
+    benchmark: BenchmarkFixture,
+    parser: SchemaParser,
+    benchmark_models_path: str,
+) -> None:
+    """Benchmark enum field detection and validation.
+
+    Performance target: < 20ms
+    """
+    schemas = parser.parse_file(benchmark_models_path)
+    complex_model = schemas["ComplexModel"]
+
+    def check_enums() -> None:
+        assert complex_model.pydantic_model is not None
+        fields = complex_model.pydantic_model.model_fields
+        # ComplexModel has Status and Priority enums
+        assert "status" in fields
+        assert "priority" in fields
+
+    benchmark(check_enums)
+
+
+# =============================================================================
+# TESTS: Parser Scaling
+# =============================================================================
+
+
+@pytest.mark.benchmark(group="parser-scale")
+def test_parser_all_models(
+    benchmark: BenchmarkFixture,
+    benchmark_models_path: str,
+) -> None:
+    """Benchmark parsing all models in benchmark_models.py (10 models).
+
+    Performance target: < 100ms
+    Tests parser scaling with multiple models.
+    """
+    parser = SchemaParser()
+
+    def parse_all() -> None:
+        schemas = parser.parse_file(benchmark_models_path)
+        # Verify all expected models are present
+        expected_models = {
+            "Contact",
+            "ComplexModel",
+            "Author",
+            "Book",
+            "Review",
+            "LargeModel",
+            "Category",
+            "Product",
+        }
+        assert expected_models.issubset(set(schemas.keys()))
+
+    benchmark(parse_all)

--- a/tests/benchmarks/test_router_benchmarks.py
+++ b/tests/benchmarks/test_router_benchmarks.py
@@ -1,0 +1,196 @@
+"""Benchmark tests for RouterGenerator performance.
+
+Tests router generation performance across various scenarios:
+- Router initialization and model registry building
+- Single model route generation
+- Router scaling with multiple models
+- Model registry lookup operations
+- Complete router generation (end-to-end)
+
+Performance targets:
+- Router initialization: < 100ms for 5 models
+- Route generation: < 50ms per model
+- Model registry lookup: < 1ms (O(1))
+"""
+
+from __future__ import annotations
+
+# =============================================================================
+# IMPORTS
+# =============================================================================
+# Third-party
+import pytest
+
+# Project/Local
+from mock_api.core.parser import SchemaParser
+from mock_api.core.router import RouterGenerator
+from mock_api.core.store import DataStore
+from mock_api.core.types import ModelSchema
+from pytest_benchmark.fixture import BenchmarkFixture
+
+# =============================================================================
+# TESTS: Router Initialization
+# =============================================================================
+
+
+@pytest.mark.benchmark(group="router-init")
+def test_router_initialization(
+    benchmark: BenchmarkFixture,
+    parsed_benchmark_schema: dict[str, ModelSchema],
+) -> None:
+    """Benchmark router initialization with model registry building.
+
+    Performance target: < 100ms for 8 models
+    Tests model registry building overhead (O(n*m) where n=models, m=fields).
+    """
+    store = DataStore()
+
+    def init_router() -> None:
+        RouterGenerator(schemas=parsed_benchmark_schema, store=store)
+
+    benchmark(init_router)
+
+
+# =============================================================================
+# TESTS: Route Generation
+# =============================================================================
+
+
+@pytest.mark.benchmark(group="router-generation")
+def test_route_generation_small(
+    benchmark: BenchmarkFixture,
+    parsed_benchmark_schema: dict[str, ModelSchema],
+) -> None:
+    """Benchmark complete route generation for all models.
+
+    Performance target: < 200ms for 8 models (8 * 5 routes = 40 routes)
+    Tests FastAPI route registration overhead.
+    """
+    store = DataStore()
+
+    def generate_routes() -> None:
+        router_gen = RouterGenerator(schemas=parsed_benchmark_schema, store=store)
+        router = router_gen.generate_routes()
+        # Each model gets 5 routes (list, create, read, update, delete)
+        assert len(router.routes) > 0
+
+    benchmark(generate_routes)
+
+
+@pytest.mark.benchmark(group="router-generation")
+def test_route_generation_single_model(
+    benchmark: BenchmarkFixture,
+    benchmark_models_path: str,
+) -> None:
+    """Benchmark route generation for single simple model.
+
+    Performance target: < 30ms for 1 model (5 routes)
+    Tests per-model route generation overhead.
+    """
+    parser = SchemaParser()
+    schemas = parser.parse_file(benchmark_models_path)
+    # Use only Contact model
+    contact_schema = {"Contact": schemas["Contact"]}
+    store = DataStore()
+
+    def generate_single() -> None:
+        router_gen = RouterGenerator(schemas=contact_schema, store=store)
+        router = router_gen.generate_routes()
+        assert len(router.routes) == 5  # list, create, read, update, delete
+
+    benchmark(generate_single)
+
+
+# =============================================================================
+# TESTS: Router Scaling
+# =============================================================================
+
+
+@pytest.mark.benchmark(group="router-scaling")
+def test_router_scaling_small(
+    benchmark: BenchmarkFixture,
+    benchmark_models_path: str,
+) -> None:
+    """Benchmark router generation with 3 models.
+
+    Performance target: < 100ms
+    Tests O(n) scaling with model count.
+    """
+    parser = SchemaParser()
+    schemas = parser.parse_file(benchmark_models_path)
+    # Use Contact, Author, Book (3 models)
+    subset_schemas = {
+        "Contact": schemas["Contact"],
+        "Author": schemas["Author"],
+        "Book": schemas["Book"],
+    }
+    store = DataStore()
+
+    def generate_small() -> None:
+        router_gen = RouterGenerator(schemas=subset_schemas, store=store)
+        router = router_gen.generate_routes()
+        assert len(router.routes) == 15  # 3 models * 5 routes
+
+    benchmark(generate_small)
+
+
+@pytest.mark.benchmark(group="router-scaling")
+def test_router_scaling_medium(
+    benchmark: BenchmarkFixture,
+    benchmark_models_path: str,
+) -> None:
+    """Benchmark router generation with 6 models.
+
+    Performance target: < 200ms
+    Tests linear scaling with increased model count.
+    """
+    parser = SchemaParser()
+    schemas = parser.parse_file(benchmark_models_path)
+    # Use 6 models
+    subset_schemas = {
+        "Contact": schemas["Contact"],
+        "ComplexModel": schemas["ComplexModel"],
+        "Author": schemas["Author"],
+        "Book": schemas["Book"],
+        "Review": schemas["Review"],
+        "LargeModel": schemas["LargeModel"],
+    }
+    store = DataStore()
+
+    def generate_medium() -> None:
+        router_gen = RouterGenerator(schemas=subset_schemas, store=store)
+        router = router_gen.generate_routes()
+        assert len(router.routes) == 30  # 6 models * 5 routes
+
+    benchmark(generate_medium)
+
+
+# =============================================================================
+# TESTS: Model Registry Operations
+# =============================================================================
+
+
+@pytest.mark.benchmark(group="router-registry")
+def test_model_registry_lookup(
+    benchmark: BenchmarkFixture,
+    parsed_benchmark_schema: dict[str, ModelSchema],
+) -> None:
+    """Benchmark model registry lookup operations.
+
+    Performance target: < 1ms (O(1) dictionary lookup)
+    Tests hash map lookup performance.
+    """
+    store = DataStore()
+    router_gen = RouterGenerator(schemas=parsed_benchmark_schema, store=store)
+    registry = router_gen.registry
+
+    def lookup_models() -> None:
+        # O(1) lookups for each model type
+        response = registry.get_response_model("Contact")
+        input_model = registry.get_input_model("Contact")
+        list_response = registry.get_list_response_model("Contact")
+        assert response is not None
+        assert input_model is not None
+        assert list_response is not None
+
+    benchmark(lookup_models)

--- a/tests/benchmarks/test_server_benchmarks.py
+++ b/tests/benchmarks/test_server_benchmarks.py
@@ -1,0 +1,302 @@
+"""Benchmark tests for Server performance.
+
+Tests server initialization and API endpoint performance:
+- Server initialization overhead
+- FastAPI app creation
+- Data pre-population
+- API endpoint throughput (GET, POST, LIST)
+- End-to-end server startup time
+
+Performance targets:
+- Server initialization: < 500ms
+- App creation: < 100ms
+- Data pre-population (100 items): < 2s
+- GET request: < 50ms
+- POST request: < 100ms
+- LIST request: < 100ms
+"""
+
+# pyright: reportUnknownMemberType=false, reportUnknownVariableType=false
+
+from __future__ import annotations
+
+# =============================================================================
+# IMPORTS
+# =============================================================================
+# Third-party
+import pytest
+from fastapi.testclient import TestClient
+
+# Project/Local
+from mock_api.core.server import Server
+from pytest_benchmark.fixture import BenchmarkFixture
+
+# =============================================================================
+# TESTS: Server Initialization
+# =============================================================================
+
+
+@pytest.mark.benchmark(group="server-init")
+def test_server_initialization(
+    benchmark: BenchmarkFixture,
+    benchmark_models_path: str,
+) -> None:
+    """Benchmark server initialization without app creation.
+
+    Performance target: < 500ms
+    Tests parser, store, router initialization overhead.
+    """
+
+    def init_server() -> None:
+        Server(
+            models_file=str(benchmark_models_path),
+            generate_data=False,
+        )
+
+    benchmark(init_server)
+
+
+@pytest.mark.benchmark(group="server-init")
+def test_app_creation(
+    benchmark: BenchmarkFixture,
+    benchmark_models_path: str,
+) -> None:
+    """Benchmark FastAPI app creation without data.
+
+    Performance target: < 100ms
+    Tests FastAPI app initialization and route registration.
+    """
+    server = Server(
+        models_file=str(benchmark_models_path),
+        generate_data=False,
+    )
+
+    def create_app() -> None:
+        server.create_app()
+
+    benchmark.pedantic(create_app, iterations=1, rounds=10)
+
+
+@pytest.mark.benchmark(group="server-init")
+def test_app_creation_with_data(
+    benchmark: BenchmarkFixture,
+    benchmark_models_path: str,
+) -> None:
+    """Benchmark FastAPI app creation with data pre-population.
+
+    Performance target: < 2s for 10 items per model
+    Tests complete server initialization including data generation.
+    """
+
+    def create_with_data() -> None:
+        server = Server(
+            models_file=str(benchmark_models_path),
+            generate_data=True,
+            data_count=10,
+        )
+        server.create_app()
+
+    benchmark.pedantic(create_with_data, iterations=1, rounds=5)
+
+
+# =============================================================================
+# TESTS: Data Population
+# =============================================================================
+
+
+@pytest.mark.benchmark(group="server-data-population")
+def test_data_prepopulation_small(
+    benchmark: BenchmarkFixture,
+    benchmark_models_path: str,
+) -> None:
+    """Benchmark pre-populating 10 items per model.
+
+    Performance target: < 500ms
+    Tests DataGenerator + Store overhead for small batches.
+    """
+
+    def populate() -> None:
+        # Create fresh server each time to avoid duplicate ID errors
+        server = Server(
+            models_file=str(benchmark_models_path),
+            generate_data=False,
+        )
+        server.populate_data()
+
+    benchmark(populate)
+
+
+@pytest.mark.benchmark(group="server-data-population")
+def test_data_prepopulation_medium(
+    benchmark: BenchmarkFixture,
+    benchmark_models_path: str,
+) -> None:
+    """Benchmark pre-populating 50 items per model.
+
+    Performance target: < 2s
+    Tests scaling of data generation and store operations.
+    """
+
+    def populate() -> None:
+        # Create fresh server each time to avoid duplicate ID errors
+        server = Server(
+            models_file=str(benchmark_models_path),
+            generate_data=False,
+        )
+        # Manually set data_count and populate
+        server.data_count = 50
+        server.populate_data()
+
+    benchmark(populate)
+
+
+# =============================================================================
+# TESTS: API Endpoint Throughput
+# =============================================================================
+
+
+@pytest.mark.benchmark(group="server-api-throughput")
+def test_api_get_throughput(
+    benchmark: BenchmarkFixture,
+    benchmark_models_path: str,
+) -> None:
+    """Benchmark GET /api/v1/{model}/{id} endpoint.
+
+    Performance target: < 50ms
+    Tests FastAPI + Store read overhead.
+    """
+    server = Server(
+        models_file=str(benchmark_models_path),
+        generate_data=True,
+        data_count=10,
+    )
+    app = server.create_app()
+    client = TestClient(app)
+
+    def get_request() -> None:
+        response = client.get("/api/v1/contacts/5")
+        assert response.status_code == 200
+
+    benchmark(get_request)
+
+
+@pytest.mark.benchmark(group="server-api-throughput")
+def test_api_post_throughput(
+    benchmark: BenchmarkFixture,
+    benchmark_models_path: str,
+) -> None:
+    """Benchmark POST /api/v1/{model} endpoint.
+
+    Performance target: < 100ms
+    Tests FastAPI + Pydantic validation + Store create overhead.
+    """
+    server = Server(
+        models_file=str(benchmark_models_path),
+        generate_data=False,
+    )
+    app = server.create_app()
+    client = TestClient(app)
+
+    counter = {"value": 0}
+
+    def post_request() -> None:
+        counter["value"] += 1
+        response = client.post(
+            "/api/v1/contacts",
+            json={
+                "name": f"Test {counter['value']}",
+                "email": f"test{counter['value']}@example.com",
+                "phone": "+1-555-0000",
+            },
+        )
+        assert response.status_code == 201
+
+    benchmark(post_request)
+
+
+@pytest.mark.benchmark(group="server-api-throughput")
+def test_api_list_throughput(
+    benchmark: BenchmarkFixture,
+    benchmark_models_path: str,
+) -> None:
+    """Benchmark GET /api/v1/{model}?page=1&page_size=20 endpoint.
+
+    Performance target: < 100ms
+    Tests FastAPI + Store list + pagination overhead.
+    """
+    server = Server(
+        models_file=str(benchmark_models_path),
+        generate_data=True,
+        data_count=100,
+    )
+    app = server.create_app()
+    client = TestClient(app)
+
+    def list_request() -> None:
+        response = client.get("/api/v1/contacts?page=1&page_size=20")
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["items"]) <= 20
+
+    benchmark(list_request)
+
+
+@pytest.mark.benchmark(group="server-api-throughput")
+def test_api_update_throughput(
+    benchmark: BenchmarkFixture,
+    benchmark_models_path: str,
+) -> None:
+    """Benchmark PUT /api/v1/{model}/{id} endpoint.
+
+    Performance target: < 100ms
+    Tests FastAPI + Pydantic validation + Store update overhead.
+    """
+    server = Server(
+        models_file=str(benchmark_models_path),
+        generate_data=True,
+        data_count=10,
+    )
+    app = server.create_app()
+    client = TestClient(app)
+
+    def update_request() -> None:
+        response = client.put(
+            "/api/v1/contacts/5",
+            json={
+                "name": "Updated Name",
+                "email": "updated@example.com",
+                "phone": "+1-555-9999",
+            },
+        )
+        assert response.status_code == 200
+
+    benchmark(update_request)
+
+
+# =============================================================================
+# TESTS: End-to-End Server Startup
+# =============================================================================
+
+
+@pytest.mark.benchmark(group="server-e2e")
+def test_complete_server_startup(
+    benchmark: BenchmarkFixture,
+    benchmark_models_path: str,
+) -> None:
+    """Benchmark complete server startup (init + app + data).
+
+    Performance target: < 3s for 20 items per model
+    Tests full cold start time from file to running server.
+    """
+
+    def full_startup() -> None:
+        server = Server(
+            models_file=str(benchmark_models_path),
+            generate_data=True,
+            data_count=20,
+        )
+        app = server.create_app()
+        assert app is not None
+        assert server.has_app
+
+    benchmark.pedantic(full_startup, iterations=1, rounds=5)

--- a/tests/benchmarks/test_store_benchmarks.py
+++ b/tests/benchmarks/test_store_benchmarks.py
@@ -1,0 +1,374 @@
+"""Benchmark tests for DataStore performance.
+
+Tests store performance across various scenarios:
+- CRUD operations (Create, Read, Update, Delete)
+- Pagination and filtering
+- Bulk operations
+- Count operations
+
+Performance targets:
+- Read (O(1)): < 1ms
+- Create: < 5ms
+- List (page_size=20): < 10ms
+- Filtered list: < 50ms
+"""
+
+from __future__ import annotations
+
+# =============================================================================
+# IMPORTS
+# =============================================================================
+# Standard library
+import contextlib
+from typing import Any
+
+# Third-party
+import pytest
+
+# Project/Local
+from mock_api.core.store import DataStore
+from pytest_benchmark.fixture import BenchmarkFixture
+
+# =============================================================================
+# TESTS: Store CRUD Operations
+# =============================================================================
+
+
+@pytest.mark.benchmark(group="store-crud")
+def test_store_create(
+    benchmark: BenchmarkFixture,
+    empty_store: DataStore,
+) -> None:
+    """Benchmark single create operation with auto-ID.
+
+    Performance target: < 5ms
+    Tests deepcopy overhead.
+    """
+    data = {"name": "Test Contact", "email": "test@example.com", "phone": "+1-555-9999"}
+
+    def create() -> None:
+        empty_store.create("Contact", data, auto_id=True)
+
+    benchmark(create)
+
+
+@pytest.mark.benchmark(group="store-crud")
+def test_store_read(
+    benchmark: BenchmarkFixture,
+    small_populated_store: DataStore,
+) -> None:
+    """Benchmark O(1) lookup by ID.
+
+    Performance target: < 1ms
+    Tests hash map lookup performance.
+    """
+
+    def read() -> None:
+        result = small_populated_store.read("Contact", 5)
+        assert result is not None
+
+    benchmark(read)
+
+
+@pytest.mark.benchmark(group="store-crud")
+def test_store_update(
+    benchmark: BenchmarkFixture,
+    small_populated_store: DataStore,
+) -> None:
+    """Benchmark direct update operation.
+
+    Performance target: < 5ms
+    Tests deepcopy overhead on update.
+    """
+    update_data = {"name": "Updated Name", "email": "updated@example.com"}
+
+    def update() -> None:
+        small_populated_store.update("Contact", 5, update_data)
+
+    benchmark(update)
+
+
+@pytest.mark.benchmark(group="store-crud")
+def test_store_delete(
+    benchmark: BenchmarkFixture,
+    small_populated_store: DataStore,
+) -> None:
+    """Benchmark delete operation.
+
+    Performance target: < 2ms
+    Tests OrderedDict.pop() performance.
+    """
+
+    def delete() -> None:
+        small_populated_store.delete("Contact", 5)
+
+    benchmark(delete)
+
+
+# =============================================================================
+# TESTS: Store List Operations
+# =============================================================================
+
+
+@pytest.mark.benchmark(group="store-list")
+def test_store_list_simple(
+    benchmark: BenchmarkFixture,
+    medium_populated_store: DataStore,
+) -> None:
+    """Benchmark pagination without filtering.
+
+    Performance target: < 10ms
+    Tests slicing performance.
+    """
+
+    def list_simple() -> None:
+        result = medium_populated_store.list("Contact", page=1, page_size=20)
+        assert len(result.items) == 20
+
+    benchmark(list_simple)
+
+
+@pytest.mark.benchmark(group="store-list")
+def test_store_list_filtered(
+    benchmark: BenchmarkFixture,
+    medium_populated_store: DataStore,
+) -> None:
+    """Benchmark filtered list operation.
+
+    Performance target: < 50ms
+    Tests O(n) full scan with filter function.
+    """
+
+    def filter_func(item: dict[str, Any]) -> bool:
+        return item.get("name") == "Person 50"
+
+    def list_filtered() -> None:
+        result = medium_populated_store.list(
+            "Contact", page=1, page_size=20, filter_func=filter_func
+        )
+        assert len(result.items) <= 20
+
+    benchmark(list_filtered)
+
+
+@pytest.mark.benchmark(group="store-list")
+def test_store_list_large_page(
+    benchmark: BenchmarkFixture,
+    large_populated_store: DataStore,
+) -> None:
+    """Benchmark pagination with large page size.
+
+    Performance target: < 30ms
+    Tests slicing with max page size.
+    """
+
+    def list_large() -> None:
+        result = large_populated_store.list("Contact", page=1, page_size=100)
+        assert len(result.items) == 100
+
+    benchmark(list_large)
+
+
+# =============================================================================
+# TESTS: Store Count Operations
+# =============================================================================
+
+
+@pytest.mark.benchmark(group="store-count")
+def test_store_count_simple(
+    benchmark: BenchmarkFixture,
+    medium_populated_store: DataStore,
+) -> None:
+    """Benchmark simple count operation.
+
+    Performance target: < 5ms
+    Tests len() call performance.
+    """
+
+    def count() -> None:
+        result = medium_populated_store.count("Contact")
+        assert result == 100
+
+    benchmark(count)
+
+
+@pytest.mark.benchmark(group="store-count")
+def test_store_count_filtered(
+    benchmark: BenchmarkFixture,
+    medium_populated_store: DataStore,
+) -> None:
+    """Benchmark filtered count operation.
+
+    Performance target: < 50ms
+    Tests O(n) scan for counting with filters.
+    """
+
+    def filter_func(item: dict[str, Any]) -> bool:
+        return item.get("name") == "Person 50"
+
+    def count_filtered() -> None:
+        result = medium_populated_store.count("Contact", filter_func=filter_func)
+        assert result >= 0
+
+    benchmark(count_filtered)
+
+
+# =============================================================================
+# TESTS: Store Bulk Operations
+# =============================================================================
+
+
+@pytest.mark.benchmark(group="store-bulk")
+def test_store_bulk_load_small(
+    benchmark: BenchmarkFixture,
+    empty_store: DataStore,
+) -> None:
+    """Benchmark loading 100 items at once.
+
+    Performance target: < 50ms
+    Tests bulk initialization performance.
+    """
+    data = {
+        "Contact": [
+            {
+                "id": i,
+                "name": f"Person {i}",
+                "email": f"person{i}@example.com",
+                "phone": f"+1-555-{i:04d}",
+            }
+            for i in range(1, 101)
+        ]
+    }
+
+    def bulk_load() -> None:
+        empty_store.load(data)
+
+    benchmark(bulk_load)
+
+
+@pytest.mark.benchmark(group="store-bulk")
+def test_store_bulk_load_medium(
+    benchmark: BenchmarkFixture,
+    empty_store: DataStore,
+) -> None:
+    """Benchmark loading 500 items at once.
+
+    Performance target: < 250ms
+    Tests bulk initialization scaling.
+    """
+    data = {
+        "Contact": [
+            {
+                "id": i,
+                "name": f"Person {i}",
+                "email": f"person{i}@example.com",
+                "phone": f"+1-555-{i:04d}",
+            }
+            for i in range(1, 501)
+        ]
+    }
+
+    def bulk_load() -> None:
+        empty_store.load(data)
+
+    benchmark(bulk_load)
+
+
+@pytest.mark.benchmark(group="store-bulk")
+def test_store_bulk_load_large(
+    benchmark: BenchmarkFixture,
+    empty_store: DataStore,
+) -> None:
+    """Benchmark loading 1000 items at once.
+
+    Performance target: < 500ms
+    Tests bulk initialization at scale.
+    """
+    data = {
+        "Contact": [
+            {
+                "id": i,
+                "name": f"Person {i}",
+                "email": f"person{i}@example.com",
+                "phone": f"+1-555-{i:04d}",
+            }
+            for i in range(1, 1001)
+        ]
+    }
+
+    def bulk_load() -> None:
+        empty_store.load(data)
+
+    benchmark(bulk_load)
+
+
+@pytest.mark.benchmark(group="store-bulk")
+def test_store_bulk_create_sequential(
+    benchmark: BenchmarkFixture,
+    empty_store: DataStore,
+) -> None:
+    """Benchmark 100 sequential create operations.
+
+    Performance target: < 500ms
+    Tests sequential create overhead with deepcopy.
+    """
+    batch_data = [
+        {
+            "name": f"Batch Contact {i}",
+            "email": f"batch{i}@example.com",
+            "phone": f"+1-555-{i:04d}",
+        }
+        for i in range(100)
+    ]
+
+    def bulk_create() -> None:
+        for contact in batch_data:
+            empty_store.create("Contact", contact, auto_id=True)
+
+    benchmark(bulk_create)
+
+
+# =============================================================================
+# TESTS: Store Edge Cases
+# =============================================================================
+
+
+@pytest.mark.benchmark(group="store-edge")
+def test_store_read_missing(
+    benchmark: BenchmarkFixture,
+    small_populated_store: DataStore,
+) -> None:
+    """Benchmark read for non-existent ID.
+
+    Performance target: < 1ms
+    Tests exception handling overhead.
+    """
+
+    def read_missing() -> None:
+        with contextlib.suppress(Exception):
+            small_populated_store.read("Contact", 99999)
+
+    benchmark(read_missing)
+
+
+@pytest.mark.benchmark(group="store-edge")
+def test_store_list_empty_result(
+    benchmark: BenchmarkFixture,
+    medium_populated_store: DataStore,
+) -> None:
+    """Benchmark list with filters that match nothing.
+
+    Performance target: < 50ms
+    Tests O(n) scan with no matches.
+    """
+
+    def filter_func(item: dict[str, Any]) -> bool:
+        return item.get("name") == "NonExistentPerson"
+
+    def list_empty() -> None:
+        result = medium_populated_store.list(
+            "Contact", page=1, page_size=20, filter_func=filter_func
+        )
+        assert len(result.items) == 0
+
+    benchmark(list_empty)

--- a/tests/fixtures/benchmark_models.py
+++ b/tests/fixtures/benchmark_models.py
@@ -1,0 +1,163 @@
+"""Pydantic models for benchmark testing.
+
+This module contains models specifically designed for performance benchmarking:
+- Contact: Simple 4-field model for baseline benchmarks
+- ComplexModel: 9-field model with enums and optional fields
+- Author/Book/Review: Models with foreign key relationships for FK resolution benchmarks
+"""
+
+from __future__ import annotations
+
+# =============================================================================
+# IMPORTS
+# =============================================================================
+# Standard library
+from datetime import datetime
+from enum import Enum
+
+# Third-party
+from pydantic import BaseModel
+
+# =============================================================================
+# SIMPLE MODEL
+# =============================================================================
+
+
+class Contact(BaseModel):
+    """Simple 4-field model for baseline benchmarks."""
+
+    id: int
+    name: str
+    email: str
+    phone: str
+
+
+# =============================================================================
+# COMPLEX MODEL
+# =============================================================================
+
+
+class Status(str, Enum):
+    """Status enumeration for ComplexModel."""
+
+    ACTIVE = "active"
+    INACTIVE = "inactive"
+    PENDING = "pending"
+    ARCHIVED = "archived"
+
+
+class Priority(str, Enum):
+    """Priority enumeration for ComplexModel."""
+
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+    CRITICAL = "critical"
+
+
+class ComplexModel(BaseModel):
+    """Complex 9-field model with enums and optional fields."""
+
+    id: int
+    title: str
+    description: str
+    status: Status
+    priority: Priority
+    score: float
+    tags: str | None = None
+    metadata: str | None = None
+    created_at: datetime
+
+
+# =============================================================================
+# FOREIGN KEY MODELS
+# =============================================================================
+
+
+class Author(BaseModel):
+    """Author model for relationship benchmarks."""
+
+    id: int
+    name: str
+    email: str
+    bio: str | None = None
+    created_at: datetime
+
+
+class Book(BaseModel):
+    """Book model with foreign key to Author."""
+
+    id: int
+    title: str
+    description: str
+    author_id: int  # Foreign key to Author
+    isbn: str
+    pages: int
+    published_at: datetime
+    created_at: datetime
+
+
+class Review(BaseModel):
+    """Review model with foreign keys to both Book and Author."""
+
+    id: int
+    book_id: int  # Foreign key to Book
+    author_id: int  # Foreign key to Author (reviewer)
+    rating: int
+    comment: str
+    created_at: datetime
+
+
+# =============================================================================
+# LARGE FIELD COUNT MODELS
+# =============================================================================
+
+
+class LargeModel(BaseModel):
+    """Model with 20 fields for field extraction benchmarks."""
+
+    id: int
+    field_01: str
+    field_02: str
+    field_03: str
+    field_04: int
+    field_05: int
+    field_06: float
+    field_07: float
+    field_08: bool
+    field_09: bool
+    field_10: datetime
+    field_11: datetime
+    field_12: str | None = None
+    field_13: str | None = None
+    field_14: int | None = None
+    field_15: int | None = None
+    field_16: float | None = None
+    field_17: float | None = None
+    field_18: bool | None = None
+    field_19: str | None = None
+    field_20: str | None = None
+
+
+# =============================================================================
+# CIRCULAR DEPENDENCY MODELS
+# =============================================================================
+
+
+class Category(BaseModel):
+    """Category with self-referential foreign key."""
+
+    id: int
+    name: str
+    parent_id: int | None = None  # Self-referential FK
+    description: str
+
+
+class Product(BaseModel):
+    """Product with FK to Category."""
+
+    id: int
+    name: str
+    category_id: int  # FK to Category
+    price: float
+    stock: int

--- a/tests/fixtures/circular_models.py
+++ b/tests/fixtures/circular_models.py
@@ -1,8 +1,17 @@
 """Test fixtures for circular dependencies."""
 
+from __future__ import annotations
+
+# =============================================================================
+# IMPORTS
+# =============================================================================
+# Third-party
 from pydantic import BaseModel
 
 
+# =============================================================================
+# TEST MODELS
+# =============================================================================
 class User(BaseModel):
     """User with manager relationship (self-referential)."""
 

--- a/tests/fixtures/empty_models.py
+++ b/tests/fixtures/empty_models.py
@@ -11,8 +11,6 @@ from __future__ import annotations
 # Standard library
 from typing import Any
 
-# Third-party
-
 # =============================================================================
 # MODULE CONTENTS
 # =============================================================================

--- a/uv.lock
+++ b/uv.lock
@@ -483,6 +483,18 @@ wheels = [
 ]
 
 [[package]]
+name = "memory-profiler"
+version = "0.61.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "psutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b2/88/e1907e1ca3488f2d9507ca8b0ae1add7b1cd5d3ca2bc8e5b329382ea2c7b/memory_profiler-0.61.0.tar.gz", hash = "sha256:4e5b73d7864a1d1292fb76a03e82a3e78ef934d06828a698d9dada76da2067b0", size = 35935, upload-time = "2022-11-15T17:57:28.994Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/26/aaca612a0634ceede20682e692a6c55e35a94c21ba36b807cc40fe910ae1/memory_profiler-0.61.0-py3-none-any.whl", hash = "sha256:400348e61031e3942ad4d4109d18753b2fb08c2f6fb8290671c5513a34182d84", size = 31803, upload-time = "2022-11-15T17:57:27.031Z" },
+]
+
+[[package]]
 name = "mock-api"
 version = "0.1.0"
 source = { editable = "." }
@@ -499,11 +511,13 @@ dependencies = [
 dev = [
     { name = "bandit" },
     { name = "httpx" },
+    { name = "memory-profiler" },
     { name = "pip-audit" },
     { name = "pre-commit" },
     { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "pytest-benchmark" },
     { name = "pytest-cov" },
     { name = "ruff" },
 ]
@@ -515,12 +529,14 @@ requires-dist = [
     { name = "faker", specifier = ">=30.0.0" },
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27.0" },
+    { name = "memory-profiler", marker = "extra == 'dev'", specifier = ">=0.61.0" },
     { name = "pip-audit", marker = "extra == 'dev'", specifier = ">=2.7" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1.350" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24.0" },
+    { name = "pytest-benchmark", marker = "extra == 'dev'", specifier = ">=4.0.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4" },
     { name = "rich", specifier = ">=13.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8" },
@@ -695,6 +711,43 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/40/f1/6d86a29246dfd2e9b6237f0b5823717f60cad94d47ddc26afa916d21f525/pre_commit-4.5.1.tar.gz", hash = "sha256:eb545fcff725875197837263e977ea257a402056661f09dae08e4b149b030a61", size = 198232, upload-time = "2025-12-16T21:14:33.552Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5d/19/fd3ef348460c80af7bb4669ea7926651d1f95c23ff2df18b9d24bab4f3fa/pre_commit-4.5.1-py2.py3-none-any.whl", hash = "sha256:3b3afd891e97337708c1674210f8eba659b52a38ea5f822ff142d10786221f77", size = 226437, upload-time = "2025-12-16T21:14:32.409Z" },
+]
+
+[[package]]
+name = "psutil"
+version = "7.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/73/cb/09e5184fb5fc0358d110fc3ca7f6b1d033800734d34cac10f4136cfac10e/psutil-7.2.1.tar.gz", hash = "sha256:f7583aec590485b43ca601dd9cea0dcd65bd7bb21d30ef4ddbf4ea6b5ed1bdd3", size = 490253, upload-time = "2025-12-29T08:26:00.169Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/8e/f0c242053a368c2aa89584ecd1b054a18683f13d6e5a318fc9ec36582c94/psutil-7.2.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:ba9f33bb525b14c3ea563b2fd521a84d2fa214ec59e3e6a2858f78d0844dd60d", size = 129624, upload-time = "2025-12-29T08:26:04.255Z" },
+    { url = "https://files.pythonhosted.org/packages/26/97/a58a4968f8990617decee234258a2b4fc7cd9e35668387646c1963e69f26/psutil-7.2.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:81442dac7abfc2f4f4385ea9e12ddf5a796721c0f6133260687fec5c3780fa49", size = 130132, upload-time = "2025-12-29T08:26:06.228Z" },
+    { url = "https://files.pythonhosted.org/packages/db/6d/ed44901e830739af5f72a85fa7ec5ff1edea7f81bfbf4875e409007149bd/psutil-7.2.1-cp313-cp313t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ea46c0d060491051d39f0d2cff4f98d5c72b288289f57a21556cc7d504db37fc", size = 180612, upload-time = "2025-12-29T08:26:08.276Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/65/b628f8459bca4efbfae50d4bf3feaab803de9a160b9d5f3bd9295a33f0c2/psutil-7.2.1-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:35630d5af80d5d0d49cfc4d64c1c13838baf6717a13effb35869a5919b854cdf", size = 183201, upload-time = "2025-12-29T08:26:10.622Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/23/851cadc9764edcc18f0effe7d0bf69f727d4cf2442deb4a9f78d4e4f30f2/psutil-7.2.1-cp313-cp313t-win_amd64.whl", hash = "sha256:923f8653416604e356073e6e0bccbe7c09990acef442def2f5640dd0faa9689f", size = 139081, upload-time = "2025-12-29T08:26:12.483Z" },
+    { url = "https://files.pythonhosted.org/packages/59/82/d63e8494ec5758029f31c6cb06d7d161175d8281e91d011a4a441c8a43b5/psutil-7.2.1-cp313-cp313t-win_arm64.whl", hash = "sha256:cfbe6b40ca48019a51827f20d830887b3107a74a79b01ceb8cc8de4ccb17b672", size = 134767, upload-time = "2025-12-29T08:26:14.528Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c2/5fb764bd61e40e1fe756a44bd4c21827228394c17414ade348e28f83cd79/psutil-7.2.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:494c513ccc53225ae23eec7fe6e1482f1b8a44674241b54561f755a898650679", size = 129716, upload-time = "2025-12-29T08:26:16.017Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/d2/935039c20e06f615d9ca6ca0ab756cf8408a19d298ffaa08666bc18dc805/psutil-7.2.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:3fce5f92c22b00cdefd1645aa58ab4877a01679e901555067b1bd77039aa589f", size = 130133, upload-time = "2025-12-29T08:26:18.009Z" },
+    { url = "https://files.pythonhosted.org/packages/77/69/19f1eb0e01d24c2b3eacbc2f78d3b5add8a89bf0bb69465bc8d563cc33de/psutil-7.2.1-cp314-cp314t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:93f3f7b0bb07711b49626e7940d6fe52aa9940ad86e8f7e74842e73189712129", size = 181518, upload-time = "2025-12-29T08:26:20.241Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/6d/7e18b1b4fa13ad370787626c95887b027656ad4829c156bb6569d02f3262/psutil-7.2.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d34d2ca888208eea2b5c68186841336a7f5e0b990edec929be909353a202768a", size = 184348, upload-time = "2025-12-29T08:26:22.215Z" },
+    { url = "https://files.pythonhosted.org/packages/98/60/1672114392dd879586d60dd97896325df47d9a130ac7401318005aab28ec/psutil-7.2.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2ceae842a78d1603753561132d5ad1b2f8a7979cb0c283f5b52fb4e6e14b1a79", size = 140400, upload-time = "2025-12-29T08:26:23.993Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/7b/d0e9d4513c46e46897b46bcfc410d51fc65735837ea57a25170f298326e6/psutil-7.2.1-cp314-cp314t-win_arm64.whl", hash = "sha256:08a2f175e48a898c8eb8eace45ce01777f4785bc744c90aa2cc7f2fa5462a266", size = 135430, upload-time = "2025-12-29T08:26:25.999Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/cf/5180eb8c8bdf6a503c6919f1da28328bd1e6b3b1b5b9d5b01ae64f019616/psutil-7.2.1-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:b2e953fcfaedcfbc952b44744f22d16575d3aa78eb4f51ae74165b4e96e55f42", size = 128137, upload-time = "2025-12-29T08:26:27.759Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/2c/78e4a789306a92ade5000da4f5de3255202c534acdadc3aac7b5458fadef/psutil-7.2.1-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:05cc68dbb8c174828624062e73078e7e35406f4ca2d0866c272c2410d8ef06d1", size = 128947, upload-time = "2025-12-29T08:26:29.548Z" },
+    { url = "https://files.pythonhosted.org/packages/29/f8/40e01c350ad9a2b3cb4e6adbcc8a83b17ee50dd5792102b6142385937db5/psutil-7.2.1-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5e38404ca2bb30ed7267a46c02f06ff842e92da3bb8c5bfdadbd35a5722314d8", size = 154694, upload-time = "2025-12-29T08:26:32.147Z" },
+    { url = "https://files.pythonhosted.org/packages/06/e4/b751cdf839c011a9714a783f120e6a86b7494eb70044d7d81a25a5cd295f/psutil-7.2.1-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ab2b98c9fc19f13f59628d94df5cc4cc4844bc572467d113a8b517d634e362c6", size = 156136, upload-time = "2025-12-29T08:26:34.079Z" },
+    { url = "https://files.pythonhosted.org/packages/44/ad/bbf6595a8134ee1e94a4487af3f132cef7fce43aef4a93b49912a48c3af7/psutil-7.2.1-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:f78baafb38436d5a128f837fab2d92c276dfb48af01a240b861ae02b2413ada8", size = 148108, upload-time = "2025-12-29T08:26:36.225Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/15/dd6fd869753ce82ff64dcbc18356093471a5a5adf4f77ed1f805d473d859/psutil-7.2.1-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:99a4cd17a5fdd1f3d014396502daa70b5ec21bf4ffe38393e152f8e449757d67", size = 147402, upload-time = "2025-12-29T08:26:39.21Z" },
+    { url = "https://files.pythonhosted.org/packages/34/68/d9317542e3f2b180c4306e3f45d3c922d7e86d8ce39f941bb9e2e9d8599e/psutil-7.2.1-cp37-abi3-win_amd64.whl", hash = "sha256:b1b0671619343aa71c20ff9767eced0483e4fc9e1f489d50923738caf6a03c17", size = 136938, upload-time = "2025-12-29T08:26:41.036Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/73/2ce007f4198c80fcf2cb24c169884f833fe93fbc03d55d302627b094ee91/psutil-7.2.1-cp37-abi3-win_arm64.whl", hash = "sha256:0d67c1822c355aa6f7314d92018fb4268a76668a536f133599b91edd48759442", size = 133836, upload-time = "2025-12-29T08:26:43.086Z" },
+]
+
+[[package]]
+name = "py-cpuinfo"
+version = "9.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/37/a8/d832f7293ebb21690860d2e01d8115e5ff6f2ae8bbdc953f0eb0fa4bd2c7/py-cpuinfo-9.0.0.tar.gz", hash = "sha256:3cdbbf3fac90dc6f118bfd64384f309edeadd902d7c8fb17f02ffa1fc3f49690", size = 104716, upload-time = "2022-10-25T20:38:06.303Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/a9/023730ba63db1e494a271cb018dcd361bd2c917ba7004c3e49d5daf795a2/py_cpuinfo-9.0.0-py3-none-any.whl", hash = "sha256:859625bc251f64e21f077d099d4162689c762b5d6a4c3c97553d56241c9674d5", size = 22335, upload-time = "2022-10-25T20:38:27.636Z" },
 ]
 
 [[package]]
@@ -879,6 +932,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+]
+
+[[package]]
+name = "pytest-benchmark"
+version = "5.2.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "py-cpuinfo" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/24/34/9f732b76456d64faffbef6232f1f9dbec7a7c4999ff46282fa418bd1af66/pytest_benchmark-5.2.3.tar.gz", hash = "sha256:deb7317998a23c650fd4ff76e1230066a76cb45dcece0aca5607143c619e7779", size = 341340, upload-time = "2025-11-09T18:48:43.215Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/29/e756e715a48959f1c0045342088d7ca9762a2f509b945f362a316e9412b7/pytest_benchmark-5.2.3-py3-none-any.whl", hash = "sha256:bc839726ad20e99aaa0d11a127445457b4219bdb9e80a1afc4b51da7f96b0803", size = 45255, upload-time = "2025-11-09T18:48:39.765Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Implements complete benchmark suite to track and prevent performance regressions across all core components.

## Changes

### Benchmark Test Suite (53 tests total)
- **test_parser_benchmarks.py**: 10 tests for schema parsing performance
- **test_generator_benchmarks.py**: 12 tests for data generation scaling  
- **test_store_benchmarks.py**: 15 tests for CRUD operations and bulk loading
- **test_router_benchmarks.py**: 6 tests for route generation and scaling
- **test_server_benchmarks.py**: 10 tests for API throughput and E2E startup

### Infrastructure
- Added pytest-benchmark configuration to pyproject.toml
- Created benchmark fixtures and test models in tests/fixtures/
- Configured .benchmarks/ directory for result storage (gitignored)

### CI Integration
- Updated ci-develop.yml with functional benchmark job
- Baseline comparison with 20% regression threshold
- Artifact storage (90-day retention) and commit comments
- Benchmarks run automatically on develop/main branches

### Developer Tools
- Added 4 Makefile targets:
  - `make benchmark` - Run all benchmarks
  - `make benchmark-compare` - Compare against baseline
  - `make benchmark-save` - Save new baseline
  - `make benchmark-report` - Generate histogram report

### Pre-commit Hook Cleanup
- Removed test-fast hook to prevent tests running on every commit
- Removed legacy git hook to avoid duplication with pre-commit framework
- Keeps linting, formatting, type checking, and commit validation

## Performance Results
All benchmarks meet performance targets:
- Parser: <10ms for simple models, <100ms for complex files
- Generator: <50ms for 10 items, <2s for 1000 items
- Store: <1ms for reads (O(1)), <10ms for list operations
- Router: <100ms for 5 models, <200ms for 8 models
- Server: <100ms app creation, <3s complete startup with data

## Test Plan
- [x] All 53 benchmark tests passing
- [x] Pre-commit hooks working without running tests
- [x] CI workflow validated
- [x] Makefile targets functional

## Related Issues
Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)