### PR TITLE
chore: remove Test PyPI publish job from main branch CI

### DIFF
--- a/.github/workflows/ci-develop.yml
+++ b/.github/workflows/ci-develop.yml
@@ -317,31 +317,3 @@ jobs:
         run: |
           echo "=== Raw Metrics ==="
           uv run radon raw mock_api -s
-
-  test-pypi-publish:
-    name: Test PyPI publish (main only)
-    if: github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
-    needs: [comprehensive-tests, package-build]
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v4
-
-      - name: Build package
-        run: uv build
-
-      - name: Publish to Test PyPI
-        continue-on-error: true
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          repository-url: https://test.pypi.org/legacy/
-          skip-existing: true
-          verbose: true


### PR DESCRIPTION
Removes the test-pypi-publish job from Develop/Main CI workflow.

Publishing to PyPI should only happen on version tags via release.yml, not on every main push.

Aligns with Linux-style workflow where main only contains merge commits.