### PR TITLE
feat: add Test PyPI environment for pre-release testing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,8 +34,30 @@ jobs:
           name: python-package-distributions
           path: dist/
 
+  publish-to-test-pypi:
+    name: Publish to Test PyPI (pre-release)
+    if: contains(github.ref_name, 'a') || contains(github.ref_name, 'b') || contains(github.ref_name, 'rc')
+    needs: [build]
+    runs-on: ubuntu-latest
+    environment:
+      name: test-pypi
+      url: https://test.pypi.org/p/mockapi-server
+
+    steps:
+      - name: Download all the dists
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Publish distribution to Test PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+
   publish-to-pypi:
-    name: Publish to PyPI
+    name: Publish to PyPI (stable)
+    if: "!(contains(github.ref_name, 'a') || contains(github.ref_name, 'b') || contains(github.ref_name, 'rc'))"
     needs: [build]
     runs-on: ubuntu-latest
     environment:
@@ -54,7 +76,8 @@ jobs:
 
   github-release:
     name: Create GitHub Release
-    needs: [publish-to-pypi]
+    if: always()
+    needs: [publish-to-test-pypi, publish-to-pypi]
     runs-on: ubuntu-latest
 
     steps:
@@ -70,6 +93,15 @@ jobs:
           name: python-package-distributions
           path: dist/
 
+      - name: Determine if pre-release
+        id: prerelease
+        run: |
+          if [[ "${{ github.ref_name }}" =~ (a|b|rc) ]]; then
+            echo "prerelease=true" >> $GITHUB_OUTPUT
+          else
+            echo "prerelease=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Create GitHub Release
         env:
           GITHUB_TOKEN: ${{ github.token }}
@@ -79,4 +111,5 @@ jobs:
           --repo '${{ github.repository }}'
           --title 'Release ${{ github.ref_name }}'
           --generate-notes
+          ${{ steps.prerelease.outputs.prerelease == 'true' && '--prerelease' || '' }}
           dist/**


### PR DESCRIPTION
## Summary

Adds support for publishing pre-releases to Test PyPI while stable releases go to production PyPI.

## Changes

**Workflow logic:**
- Pre-release tags (containing a, b, or rc) → Test PyPI environment
- Stable release tags → Production PyPI environment
- Pre-releases marked as pre-release in GitHub Releases

**Examples:**
- `v0.1.0a1` → Test PyPI (alpha)
- `v0.1.0b1` → Test PyPI (beta)
- `v0.1.0rc1` → Test PyPI (release candidate)
- `v0.1.0` → Production PyPI (stable)

## Configuration Required

### 1. Test PyPI Trusted Publisher

Go to https://test.pypi.org/manage/account/publishing/ and add:

- **PyPI Project Name**: `mock-api`
- **Owner**: `sudzxd`
- **Repository**: `mock-api`
- **Workflow**: `release.yml`
- **Environment**: `test-pypi`

### 2. GitHub Environment (Optional)

Create `test-pypi` environment in Settings → Environments with:
- Deployment protection rules (optional)
- No secrets needed (uses OIDC)

## Benefits

- ✅ Test releases safely before production
- ✅ Different protection rules per environment
- ✅ Clear separation of pre-release/stable workflows
- ✅ No API tokens needed (OIDC trusted publishing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)