### PR TITLE
Release v0.1.0a2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,7 +62,7 @@ htmlcov/
 # Project specific
 *.db
 *.sqlite
-mock-api.log
+mockapi-server.log
 
 # Planning docs (keep local, don't commit)
 docs/GOLD_STANDARD_CHECKLIST.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0a2] - 2026-01-10
+
+### Fixed
+
+- Renamed package from `mock-api` to `mockapi-server` to match repository name
+- Updated CLI command from `mock-api` to `mockapi-server`
+- Updated all GitHub URLs to point to `mockapi-server` repository
+
 ## [0.1.0a1] - 2026-01-10
 
 ### Added
@@ -35,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Comprehensive test suite (167 tests, 90%+ coverage)
 - Development tooling: Makefile, ruff, pyright, pytest
 
-[Unreleased]: https://github.com/sudzxd/mockapi-server/compare/v0.1.0a1...HEAD
+[Unreleased]: https://github.com/sudzxd/mockapi-server/compare/v0.1.0a2...HEAD
+[0.1.0a2]: https://github.com/sudzxd/mockapi-server/releases/tag/v0.1.0a2
 [0.1.0a1]: https://github.com/sudzxd/mockapi-server/releases/tag/v0.1.0a1
 [0.1.0]: https://github.com/sudzxd/mockapi-server/releases/tag/v0.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [ "hatchling" ]
 
 [project]
 name = "mockapi-server"
-version = "0.1.0a1"
+version = "0.1.0a2"
 description = "Generate full-featured REST APIs from Pydantic models or TypeScript types"
 readme = "README.md"
 keywords = [ "api", "fake-data", "fastapi", "mock", "pydantic", "rest", "testing" ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ build-backend = "hatchling.build"
 requires = [ "hatchling" ]
 
 [project]
-name = "mock-api"
+name = "mockapi-server"
 version = "0.1.0a1"
 description = "Generate full-featured REST APIs from Pydantic models or TypeScript types"
 readme = "README.md"
@@ -45,11 +45,11 @@ optional-dependencies.dev = [
   "pytest-cov>=4",
   "ruff>=0.8",
 ]
-urls.Documentation = "https://github.com/sudzxd/mock-api#readme"
-urls.Homepage = "https://github.com/sudzxd/mock-api"
-urls.Issues = "https://github.com/sudzxd/mock-api/issues"
-urls.Repository = "https://github.com/sudzxd/mock-api"
-scripts.mock-api = "mock_api.cli.main:cli"
+urls.Documentation = "https://github.com/sudzxd/mockapi-server#readme"
+urls.Homepage = "https://github.com/sudzxd/mockapi-server"
+urls.Issues = "https://github.com/sudzxd/mockapi-server/issues"
+urls.Repository = "https://github.com/sudzxd/mockapi-server"
+scripts.mockapi-server = "mock_api.cli.main:cli"
 
 [tool.hatch.build.targets.wheel]
 packages = [ "mock_api" ]

--- a/uv.lock
+++ b/uv.lock
@@ -495,8 +495,8 @@ wheels = [
 ]
 
 [[package]]
-name = "mock-api"
-version = "0.1.0"
+name = "mockapi-server"
+version = "0.1.0a1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -525,22 +525,22 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "bandit", marker = "extra == 'dev'", specifier = ">=1.7" },
-    { name = "click", specifier = ">=8.1.0" },
-    { name = "faker", specifier = ">=30.0.0" },
-    { name = "fastapi", specifier = ">=0.115.0" },
-    { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27.0" },
-    { name = "memory-profiler", marker = "extra == 'dev'", specifier = ">=0.61.0" },
+    { name = "click", specifier = ">=8.1" },
+    { name = "faker", specifier = ">=30" },
+    { name = "fastapi", specifier = ">=0.115" },
+    { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27" },
+    { name = "memory-profiler", marker = "extra == 'dev'", specifier = ">=0.61" },
     { name = "pip-audit", marker = "extra == 'dev'", specifier = ">=2.7" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3" },
-    { name = "pydantic", specifier = ">=2.0.0" },
+    { name = "pydantic", specifier = ">=2" },
     { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1.350" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8" },
-    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24.0" },
-    { name = "pytest-benchmark", marker = "extra == 'dev'", specifier = ">=4.0.0" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24" },
+    { name = "pytest-benchmark", marker = "extra == 'dev'", specifier = ">=4" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4" },
-    { name = "rich", specifier = ">=13.0.0" },
+    { name = "rich", specifier = ">=13" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8" },
-    { name = "uvicorn", extras = ["standard"], specifier = ">=0.30.0" },
+    { name = "uvicorn", extras = ["standard"], specifier = ">=0.30" },
 ]
 provides-extras = ["dev"]
 


### PR DESCRIPTION
## Release v0.1.0a2

Second alpha release with corrected package name.

### Fixed
- Renamed package from `mock-api` to `mockapi-server` to match repository name
- Updated CLI command from `mock-api` to `mockapi-server`  
- Updated all GitHub URLs to point to `mockapi-server` repository

### Test Plan
- [x] All CI checks passing
- [x] Test coverage at 92%+
- [x] Type checking with pyright passing
- [ ] Publish to Test PyPI as `mockapi-server`
- [ ] Manual testing of alpha release