### PR TITLE
feat: add bulk operations for create, update, and delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ mockapi-server serve --models models.py --generate-data
 - **Type-safe** - Built on Pydantic for automatic validation
 - **Smart data** - Realistic fake data based on field names
 - **Auto relationships** - Detects foreign keys, creates nested routes
+- **Bulk operations** - Create, update, delete multiple entities atomically
 - **Stateful** - CRUD operations persist during session
 - **OpenAPI** - Auto-generated interactive docs
 
@@ -62,6 +63,7 @@ mockapi-server serve --models models.py --generate-data --data-count 50
 Access your API at `http://localhost:3000/api/v1` with auto-generated endpoints:
 - `GET /users`, `GET /users/:id`
 - `POST /users`, `PUT /users/:id`, `DELETE /users/:id`
+- `POST /users/bulk`, `PUT /users/bulk`, `DELETE /users/bulk?ids=1,2,3`
 - Interactive docs at `/docs`
 
 ## Examples

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -417,6 +417,30 @@ DELETE /api/v1/users/{id}
 
 **Response (204 No Content)**
 
+### Bulk Operations
+
+Process multiple entities in a single request. All-or-nothing by default.
+
+**Bulk Create:** `POST /api/v1/users/bulk` with `{"data": [...]}`
+**Bulk Update:** `PUT /api/v1/users/bulk` with `{"data": [{id: 1, ...}, ...]}`
+**Bulk Delete:** `DELETE /api/v1/users/bulk?ids=1,2,3`
+
+**Configuration:**
+```yaml
+bulk_operations:
+  max_batch_size: 1000  # Max items per request (default: 1000, max: 10000)
+  allow_partial: false  # Continue on errors (default: false)
+```
+
+**Response format:**
+```json
+{
+  "created": 2,  // or "updated", "deleted"
+  "data": [...],  // or "ids" for delete
+  "errors": []   // only if allow_partial=true
+}
+```
+
 ---
 
 ## Query Parameters

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -47,6 +47,31 @@ curl -X POST http://localhost:3000/api/v1/users \
   -d '{"id": 999, "name": "Test", "email": "test@example.com", "created_at": "2025-01-10T10:00:00Z"}'
 ```
 
+### Bulk Operations
+
+Process multiple entities in one request.
+
+```bash
+# Bulk create
+curl -X POST http://localhost:3000/api/v1/users/bulk \
+  -H "Content-Type: application/json" \
+  -d '{"data": [
+    {"name": "Alice", "email": "alice@example.com", "created_at": "2025-01-10T10:00:00Z"},
+    {"name": "Bob", "email": "bob@example.com", "created_at": "2025-01-10T11:00:00Z"}
+  ]}'
+
+# Bulk update
+curl -X PUT http://localhost:3000/api/v1/users/bulk \
+  -H "Content-Type: application/json" \
+  -d '{"data": [
+    {"id": 1, "name": "Alice Updated", "email": "alice@example.com", "created_at": "2025-01-10T10:00:00Z"},
+    {"id": 2, "name": "Bob Updated", "email": "bob@example.com", "created_at": "2025-01-10T11:00:00Z"}
+  ]}'
+
+# Bulk delete
+curl -X DELETE "http://localhost:3000/api/v1/users/bulk?ids=1,2,3"
+```
+
 ## Blog with Relationships
 
 Multi-model API with foreign keys.

--- a/mock_api/core/config.py
+++ b/mock_api/core/config.py
@@ -43,6 +43,7 @@ from mock_api.core.constants import (
     DEFAULT_HOST,
     DEFAULT_LIMIT,
     DEFAULT_LOG_LEVEL,
+    DEFAULT_MAX_BATCH_SIZE,
     DEFAULT_MAX_FILTERS,
     DEFAULT_MAX_SORT_FIELDS,
     DEFAULT_PAGE_SIZE,
@@ -50,10 +51,12 @@ from mock_api.core.constants import (
     DEFAULT_SEED_COUNT,
     DEFAULT_STRICT_MODE,
     ENV_VAR_PREFIX,
+    MAX_BATCH_SIZE_LIMIT,
     MAX_LIMIT,
     MAX_PAGE_SIZE,
     MAX_PORT,
     MAX_SEED_COUNT,
+    MIN_BATCH_SIZE,
     MIN_LIMIT,
     MIN_PAGE_SIZE,
     MIN_PORT,
@@ -171,6 +174,29 @@ class FilterSortConfig(BaseModel):
     model_config = {"frozen": False, "extra": "forbid"}
 
 
+class BulkOperationsConfig(BaseModel):
+    """Bulk operations configuration schema.
+
+    Attributes:
+        max_batch_size: Maximum number of items allowed in a single bulk operation.
+        allow_partial: If True, continue processing items even if some fail.
+    """
+
+    max_batch_size: int = Field(
+        default=DEFAULT_MAX_BATCH_SIZE,
+        description="Maximum number of items in a single bulk operation",
+        ge=MIN_BATCH_SIZE,
+        le=MAX_BATCH_SIZE_LIMIT,
+    )
+
+    allow_partial: bool = Field(
+        default=False,
+        description="Allow partial success in bulk operations",
+    )
+
+    model_config = {"frozen": False, "extra": "forbid"}
+
+
 class Config(BaseModel):
     """Configuration schema for mockapi-server.
 
@@ -241,6 +267,11 @@ class Config(BaseModel):
     filter_sort: FilterSortConfig = Field(
         default_factory=FilterSortConfig,
         description="Filtering and sorting configuration",
+    )
+
+    bulk_operations: BulkOperationsConfig = Field(
+        default_factory=BulkOperationsConfig,
+        description="Bulk operations configuration",
     )
 
     @field_validator("locale")

--- a/mock_api/core/constants.py
+++ b/mock_api/core/constants.py
@@ -279,6 +279,11 @@ DEFAULT_PAGE_NUMBER = 1
 DEFAULT_MAX_FILTERS = 10
 DEFAULT_MAX_SORT_FIELDS = 5
 
+# Bulk operations defaults
+DEFAULT_MAX_BATCH_SIZE = 1000
+MAX_BATCH_SIZE_LIMIT = 10000
+MIN_BATCH_SIZE = 1
+
 # Filtering and sorting delimiters
 FILTER_OPERATOR_DELIMITER = "__"
 SORT_DESC_PREFIX = "-"
@@ -331,6 +336,24 @@ class ResponseKey(StrEnum):
     # Offset-based pagination fields
     OFFSET = "offset"
     LIMIT = "limit"
+
+
+class BulkResponseKey(StrEnum):
+    """Keys used in bulk operation response JSON structures."""
+
+    CREATED = "created"
+    UPDATED = "updated"
+    DELETED = "deleted"
+    DATA = "data"
+    IDS = "ids"
+    ERRORS = "errors"
+    FAILED = "failed"
+
+
+class BulkQueryParam(StrEnum):
+    """Query parameter names for bulk operations."""
+
+    IDS = "ids"
 
 
 class ModelName(StrEnum):

--- a/mock_api/core/exceptions.py
+++ b/mock_api/core/exceptions.py
@@ -15,7 +15,8 @@ Exception Hierarchy:
     ├── ModelNotFoundError
     ├── StoreError
     │   ├── InstanceNotFoundError
-    │   └── DuplicateInstanceError
+    │   ├── DuplicateInstanceError
+    │   └── BatchSizeExceededError
     └── InitializationError
         ├── FileExistsError
         └── InvalidProjectNameError
@@ -292,6 +293,31 @@ class DuplicateInstanceError(StoreError):
         super().__init__(message, suggestion)
         self.model_name = model_name
         self.instance_id = instance_id
+
+
+class BatchSizeExceededError(StoreError):
+    """Raised when bulk operation batch size exceeds the configured limit.
+
+    Example:
+        >>> raise BatchSizeExceededError(1500, 1000)
+        BatchSizeExceededError: Batch size 1500 exceeds maximum allowed: 1000
+    """
+
+    def __init__(self, batch_size: int, max_batch_size: int) -> None:
+        """Initialize the exception.
+
+        Args:
+            batch_size: The actual batch size requested.
+            max_batch_size: The maximum allowed batch size.
+        """
+        message = f"Batch size {batch_size} exceeds maximum allowed: {max_batch_size}"
+        suggestion = (
+            f"Reduce batch size to {max_batch_size} or fewer items, "
+            "or increase max_batch_size in configuration."
+        )
+        super().__init__(message, suggestion)
+        self.batch_size = batch_size
+        self.max_batch_size = max_batch_size
 
 
 # =============================================================================

--- a/mock_api/core/router.py
+++ b/mock_api/core/router.py
@@ -306,15 +306,16 @@ class RouterGenerator:
         tag = model_name
 
         # Routes use registry for type-safe model access
+        # Add bulk operations first to avoid path conflicts with /{instance_id}
+        self._add_bulk_create_route(model_name, base_path, tag)
+        self._add_bulk_update_route(model_name, base_path, tag)
+        self._add_bulk_delete_route(model_name, base_path, tag)
+        # Regular CRUD operations
         self._add_list_route(model_name, base_path, tag)
         self._add_create_route(model_name, base_path, tag)
         self._add_read_route(model_name, base_path, tag)
         self._add_update_route(model_name, base_path, tag)
         self._add_delete_route(model_name, base_path, tag)
-        # Bulk operations
-        self._add_bulk_create_route(model_name, base_path, tag)
-        self._add_bulk_update_route(model_name, base_path, tag)
-        self._add_bulk_delete_route(model_name, base_path, tag)
 
     def _add_list_route(self, model_name: str, base_path: str, tag: str) -> None:
         """Add LIST route (GET /models) with filtering, sorting, and pagination."""

--- a/mock_api/core/router.py
+++ b/mock_api/core/router.py
@@ -44,6 +44,7 @@ from .constants import (
     URL_ID_PATH_SEGMENT,
     URL_PATH_SEPARATOR,
     URL_PLURAL_SUFFIX,
+    BulkResponseKey,
     FilterOperator,
     HTTPStatus,
     ModelName,
@@ -310,6 +311,10 @@ class RouterGenerator:
         self._add_read_route(model_name, base_path, tag)
         self._add_update_route(model_name, base_path, tag)
         self._add_delete_route(model_name, base_path, tag)
+        # Bulk operations
+        self._add_bulk_create_route(model_name, base_path, tag)
+        self._add_bulk_update_route(model_name, base_path, tag)
+        self._add_bulk_delete_route(model_name, base_path, tag)
 
     def _add_list_route(self, model_name: str, base_path: str, tag: str) -> None:
         """Add LIST route (GET /models) with filtering, sorting, and pagination."""
@@ -474,6 +479,196 @@ class RouterGenerator:
                 raise HTTPException(
                     status_code=HTTPStatus.NOT_FOUND, detail=RouteDescription.NOT_FOUND
                 )
+
+    def _add_bulk_create_route(self, model_name: str, base_path: str, tag: str) -> None:
+        """Add BULK CREATE route (POST /models/bulk)."""
+        input_model = self._registry.get_input_model(model_name)
+
+        async def bulk_create_handler(request_data: dict[str, Any]) -> dict[str, Any]:
+            # Extract data array
+            if BulkResponseKey.DATA not in request_data:
+                raise HTTPException(
+                    status_code=HTTPStatus.BAD_REQUEST,
+                    detail=f"Missing required field '{BulkResponseKey.DATA}'",
+                )
+
+            data_list = request_data[BulkResponseKey.DATA]
+
+            # Validate batch size
+            max_batch_size = self._config.bulk_operations.max_batch_size
+            if len(data_list) > max_batch_size:
+                detail = (
+                    f"Batch size {len(data_list)} exceeds maximum: {max_batch_size}"
+                )
+                raise HTTPException(
+                    status_code=HTTPStatus.BAD_REQUEST,
+                    detail=detail,
+                )
+
+            # Validate each item
+            validated_items: list[dict[str, Any]] = []
+            for idx, item in enumerate(data_list):
+                try:
+                    validated = input_model.model_validate(item)
+                    validated_items.append(validated.model_dump())
+                except ValidationError as e:
+                    raise HTTPException(
+                        status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
+                        detail={
+                            "message": f"Validation failed for item at index {idx}",
+                            "errors": e.errors(),
+                        },
+                    ) from None
+
+            # Perform bulk create
+            allow_partial = self._config.bulk_operations.allow_partial
+            return self.store.bulk_create(
+                model_name,
+                validated_items,
+                allow_partial=allow_partial,
+                max_batch_size=max_batch_size,
+            )
+
+        # Override annotation for OpenAPI
+        bulk_create_handler.__annotations__["request_data"] = dict[str, Any]
+
+        self._router.add_api_route(
+            f"{base_path}/bulk",
+            bulk_create_handler,
+            methods=["POST"],
+            status_code=HTTPStatus.CREATED,
+            tags=[tag],
+            summary=f"Bulk create {model_name}s",
+            description="Create multiple instances in a single request. "
+            "All items must pass validation.",
+        )
+
+    def _add_bulk_update_route(self, model_name: str, base_path: str, tag: str) -> None:
+        """Add BULK UPDATE route (PUT /models/bulk)."""
+        input_model = self._registry.get_input_model(model_name)
+
+        async def bulk_update_handler(request_data: dict[str, Any]) -> dict[str, Any]:
+            # Extract data array
+            if BulkResponseKey.DATA not in request_data:
+                raise HTTPException(
+                    status_code=HTTPStatus.BAD_REQUEST,
+                    detail=f"Missing required field '{BulkResponseKey.DATA}'",
+                )
+
+            data_list = request_data[BulkResponseKey.DATA]
+
+            # Validate batch size
+            max_batch_size = self._config.bulk_operations.max_batch_size
+            if len(data_list) > max_batch_size:
+                detail = (
+                    f"Batch size {len(data_list)} exceeds maximum: {max_batch_size}"
+                )
+                raise HTTPException(
+                    status_code=HTTPStatus.BAD_REQUEST,
+                    detail=detail,
+                )
+
+            # Validate each item has ID and valid fields
+            validated_items: list[dict[str, Any]] = []
+            for idx, item in enumerate(data_list):
+                if PRIMARY_KEY_FIELD not in item:
+                    raise HTTPException(
+                        status_code=HTTPStatus.BAD_REQUEST,
+                        detail=f"Missing '{PRIMARY_KEY_FIELD}' for item at index {idx}",
+                    )
+
+                try:
+                    # Validate non-ID fields
+                    item_copy = item.copy()
+                    instance_id = item_copy.pop(PRIMARY_KEY_FIELD)
+                    validated = input_model.model_validate(item_copy)
+                    validated_data = validated.model_dump()
+                    validated_data[PRIMARY_KEY_FIELD] = instance_id
+                    validated_items.append(validated_data)
+                except ValidationError as e:
+                    raise HTTPException(
+                        status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
+                        detail={
+                            "message": f"Validation failed for item at index {idx}",
+                            "errors": e.errors(),
+                        },
+                    ) from None
+
+            # Perform bulk update
+            allow_partial = self._config.bulk_operations.allow_partial
+            try:
+                return self.store.bulk_update(
+                    model_name,
+                    validated_items,
+                    allow_partial=allow_partial,
+                    max_batch_size=max_batch_size,
+                )
+            except InstanceNotFoundError as e:
+                raise HTTPException(
+                    status_code=HTTPStatus.NOT_FOUND,
+                    detail=str(e),
+                ) from None
+
+        # Override annotation for OpenAPI
+        bulk_update_handler.__annotations__["request_data"] = dict[str, Any]
+
+        self._router.add_api_route(
+            f"{base_path}/bulk",
+            bulk_update_handler,
+            methods=["PUT"],
+            status_code=HTTPStatus.OK,
+            tags=[tag],
+            summary=f"Bulk update {model_name}s",
+            description="Update multiple instances in a single request. "
+            "Each item must include 'id' field.",
+        )
+
+    def _add_bulk_delete_route(self, model_name: str, base_path: str, tag: str) -> None:
+        """Add BULK DELETE route (DELETE /models/bulk?ids=1,2,3)."""
+
+        @self._router.delete(
+            f"{base_path}/bulk",
+            status_code=HTTPStatus.OK,
+            tags=[tag],
+            summary=f"Bulk delete {model_name}s",
+            description="Delete multiple instances by IDs. "
+            "Provide IDs as comma-separated query parameter: ?ids=1,2,3",
+        )
+        async def bulk_delete_handler(
+            ids: str = Query(..., description="Comma-separated list of IDs to delete"),
+        ) -> dict[str, Any]:
+            # Parse IDs
+            try:
+                id_list = [int(id_str.strip()) for id_str in ids.split(",")]
+            except ValueError as e:
+                raise HTTPException(
+                    status_code=HTTPStatus.BAD_REQUEST,
+                    detail="Invalid ID format. IDs must be integers.",
+                ) from e
+
+            # Validate batch size
+            max_batch_size = self._config.bulk_operations.max_batch_size
+            if len(id_list) > max_batch_size:
+                detail = f"Batch size {len(id_list)} exceeds maximum: {max_batch_size}"
+                raise HTTPException(
+                    status_code=HTTPStatus.BAD_REQUEST,
+                    detail=detail,
+                )
+
+            # Perform bulk delete
+            allow_partial = self._config.bulk_operations.allow_partial
+            try:
+                return self.store.bulk_delete(
+                    model_name,
+                    id_list,
+                    allow_partial=allow_partial,
+                    max_batch_size=max_batch_size,
+                )
+            except InstanceNotFoundError as e:
+                raise HTTPException(
+                    status_code=HTTPStatus.NOT_FOUND,
+                    detail=str(e),
+                ) from None
 
     # =============================================================================
     # FILTER PARSING

--- a/mock_api/core/store.py
+++ b/mock_api/core/store.py
@@ -421,6 +421,10 @@ class DataStore:
         """
         self._validate_batch_size(len(data_list), max_batch_size)
 
+        # Early return for empty list
+        if not data_list:
+            return self._build_bulk_result(BulkResponseKey.UPDATED, 0, [], [])
+
         with self._lock:
             if model_name not in self._data:
                 if not allow_partial:
@@ -510,6 +514,12 @@ class DataStore:
             3
         """
         self._validate_batch_size(len(ids), max_batch_size)
+
+        # Early return for empty list
+        if not ids:
+            return self._build_bulk_result(
+                BulkResponseKey.DELETED, 0, [], [], data_key=BulkResponseKey.IDS
+            )
 
         with self._lock:
             if model_name not in self._data:

--- a/mock_api/core/store.py
+++ b/mock_api/core/store.py
@@ -35,11 +35,24 @@ from .constants import (
     MIN_LIMIT,
     MIN_PAGE_SIZE,
     PRIMARY_KEY_FIELD,
+    BulkResponseKey,
     FilterOperator,
     SortDirection,
 )
-from .exceptions import DuplicateInstanceError, InstanceNotFoundError, StoreError
-from .types import FilterSpec, PaginationInfo, PaginationParams, QueryResult, SortSpec
+from .exceptions import (
+    BatchSizeExceededError,
+    DuplicateInstanceError,
+    InstanceNotFoundError,
+    StoreError,
+)
+from .types import (
+    BulkOperationError,
+    FilterSpec,
+    PaginationInfo,
+    PaginationParams,
+    QueryResult,
+    SortSpec,
+)
 
 # =============================================================================
 # TYPES & CONSTANTS
@@ -291,6 +304,273 @@ class DataStore:
                 return True
 
             return False
+
+    def bulk_create(
+        self,
+        model_name: str,
+        data_list: list[dict[str, Any]],
+        allow_partial: bool = False,
+        max_batch_size: int | None = None,
+    ) -> dict[str, Any]:
+        """Create multiple instances atomically.
+
+        Args:
+            model_name: Name of the model to create.
+            data_list: List of instance dictionaries to create.
+            allow_partial: If True, continue on errors; if False, rollback on
+                first error.
+            max_batch_size: Maximum batch size allowed (optional validation).
+
+        Returns:
+            Dict with 'created' count, 'data' list, and optional 'errors' list.
+
+        Raises:
+            BatchSizeExceededError: If batch size exceeds maximum.
+
+        Time Complexity: O(n) where n is batch size
+
+        Example:
+            >>> result = store.bulk_create("User", [
+            ...     {"name": "Alice"},
+            ...     {"name": "Bob"}
+            ... ])
+            >>> result["created"]
+            2
+        """
+        self._validate_batch_size(len(data_list), max_batch_size)
+
+        with self._lock:
+            # Ensure model exists
+            if model_name not in self._data:
+                self._data[model_name] = OrderedDict()
+                self._id_counters[model_name] = 0
+
+            created_items: list[dict[str, Any]] = []
+            created_ids: list[int] = []
+            errors: list[BulkOperationError] = []
+
+            for idx, data in enumerate(data_list):
+                try:
+                    instance = deepcopy(data)
+
+                    # Auto-assign ID
+                    if PRIMARY_KEY_FIELD not in instance:
+                        self._id_counters[model_name] += 1
+                        instance[PRIMARY_KEY_FIELD] = self._id_counters[model_name]
+
+                    instance_id = instance[PRIMARY_KEY_FIELD]
+
+                    # Check for duplicate
+                    self._check_duplicate_id(model_name, instance_id)
+
+                    # Add to store
+                    self._data[model_name][instance_id] = instance
+                    created_items.append(deepcopy(instance))
+                    created_ids.append(instance_id)
+
+                except Exception as e:
+                    error = BulkOperationError(index=idx, item=data, error=str(e))
+                    errors.append(error)
+
+                    if not allow_partial:
+                        # Rollback all created items
+                        for created_id in created_ids:
+                            self._data[model_name].pop(created_id, None)
+                        raise
+
+            logger.info(
+                f"Bulk created {len(created_items)}/{len(data_list)} {model_name}(s)"
+            )
+
+            return self._build_bulk_result(
+                BulkResponseKey.CREATED, len(created_items), created_items, errors
+            )
+
+    def bulk_update(
+        self,
+        model_name: str,
+        data_list: list[dict[str, Any]],
+        allow_partial: bool = False,
+        max_batch_size: int | None = None,
+    ) -> dict[str, Any]:
+        """Update multiple instances atomically.
+
+        Args:
+            model_name: Name of the model.
+            data_list: List of dicts with 'id' and fields to update.
+            allow_partial: If True, continue on errors; if False, rollback on
+                first error.
+            max_batch_size: Maximum batch size allowed (optional validation).
+
+        Returns:
+            Dict with 'updated' count, 'data' list, and optional 'errors' list.
+
+        Raises:
+            BatchSizeExceededError: If batch size exceeds maximum.
+            InstanceNotFoundError: If instance not found (when not in partial mode).
+
+        Time Complexity: O(n) where n is batch size
+
+        Example:
+            >>> result = store.bulk_update("User", [
+            ...     {"id": 1, "name": "Alice Updated"},
+            ...     {"id": 2, "name": "Bob Updated"}
+            ... ])
+            >>> result["updated"]
+            2
+        """
+        self._validate_batch_size(len(data_list), max_batch_size)
+
+        with self._lock:
+            if model_name not in self._data:
+                if not allow_partial:
+                    raise InstanceNotFoundError(model_name, -1)
+                return self._build_bulk_result(
+                    BulkResponseKey.UPDATED,
+                    0,
+                    [],
+                    [
+                        BulkOperationError(idx, data, f"Model {model_name} not found")
+                        for idx, data in enumerate(data_list)
+                    ],
+                )
+
+            updated_items: list[dict[str, Any]] = []
+            original_values: dict[int, dict[str, Any]] = {}
+            errors: list[BulkOperationError] = []
+
+            for idx, data in enumerate(data_list):
+                try:
+                    # Validate ID present
+                    self._validate_id_present(data)
+
+                    instance_id = data[PRIMARY_KEY_FIELD]
+
+                    # Check exists
+                    self._check_instance_exists(model_name, instance_id)
+
+                    # Store original for rollback
+                    original_values[instance_id] = deepcopy(
+                        self._data[model_name][instance_id]
+                    )
+
+                    # Update fields
+                    instance = self._data[model_name][instance_id]
+                    instance.update(data)
+                    instance[PRIMARY_KEY_FIELD] = instance_id
+
+                    updated_items.append(deepcopy(instance))
+
+                except Exception as e:
+                    error = BulkOperationError(index=idx, item=data, error=str(e))
+                    errors.append(error)
+
+                    if not allow_partial:
+                        # Rollback all updates
+                        for orig_id, orig_data in original_values.items():
+                            self._data[model_name][orig_id] = orig_data
+                        raise
+
+            logger.info(
+                f"Bulk updated {len(updated_items)}/{len(data_list)} {model_name}(s)"
+            )
+
+            return self._build_bulk_result(
+                BulkResponseKey.UPDATED, len(updated_items), updated_items, errors
+            )
+
+    def bulk_delete(
+        self,
+        model_name: str,
+        ids: list[int],
+        allow_partial: bool = False,
+        max_batch_size: int | None = None,
+    ) -> dict[str, Any]:
+        """Delete multiple instances atomically.
+
+        Args:
+            model_name: Name of the model.
+            ids: List of instance IDs to delete.
+            allow_partial: If True, continue on errors; if False, rollback on
+                first error.
+            max_batch_size: Maximum batch size allowed (optional validation).
+
+        Returns:
+            Dict with 'deleted' count, 'ids' list, and optional 'errors' list.
+
+        Raises:
+            BatchSizeExceededError: If batch size exceeds maximum.
+            InstanceNotFoundError: If instance not found (when not in partial mode).
+
+        Time Complexity: O(n) where n is batch size
+
+        Example:
+            >>> result = store.bulk_delete("User", [1, 2, 3])
+            >>> result["deleted"]
+            3
+        """
+        self._validate_batch_size(len(ids), max_batch_size)
+
+        with self._lock:
+            if model_name not in self._data:
+                if not allow_partial:
+                    raise InstanceNotFoundError(model_name, -1)
+                return self._build_bulk_result(
+                    BulkResponseKey.DELETED,
+                    0,
+                    [],
+                    [
+                        BulkOperationError(
+                            idx,
+                            {PRIMARY_KEY_FIELD: instance_id},
+                            f"Model {model_name} not found",
+                        )
+                        for idx, instance_id in enumerate(ids)
+                    ],
+                    data_key=BulkResponseKey.IDS,
+                )
+
+            deleted_ids: list[int] = []
+            deleted_instances: dict[int, dict[str, Any]] = {}
+            errors: list[BulkOperationError] = []
+
+            for idx, instance_id in enumerate(ids):
+                try:
+                    # Check exists
+                    self._check_instance_exists(model_name, instance_id)
+
+                    # Store for rollback
+                    deleted_instances[instance_id] = deepcopy(
+                        self._data[model_name][instance_id]
+                    )
+
+                    # Delete
+                    self._data[model_name].pop(instance_id)
+                    deleted_ids.append(instance_id)
+
+                except Exception as e:
+                    error = BulkOperationError(
+                        index=idx,
+                        item={PRIMARY_KEY_FIELD: instance_id},
+                        error=str(e),
+                    )
+                    errors.append(error)
+
+                    if not allow_partial:
+                        # Rollback all deletions
+                        for del_id, del_instance in deleted_instances.items():
+                            self._data[model_name][del_id] = del_instance
+                        raise
+
+            logger.info(f"Bulk deleted {len(deleted_ids)}/{len(ids)} {model_name}(s)")
+
+            return self._build_bulk_result(
+                BulkResponseKey.DELETED,
+                len(deleted_ids),
+                deleted_ids,
+                errors,
+                data_key=BulkResponseKey.IDS,
+            )
 
     def list(
         self,
@@ -626,3 +906,85 @@ class DataStore:
         """
         with self._lock:
             return list(self._data.keys())
+
+    # =============================================================================
+    # PRIVATE HELPERS: Bulk Operations
+    # =============================================================================
+
+    def _validate_batch_size(self, batch_size: int, max_batch_size: int | None) -> None:
+        """Validate batch size against maximum allowed.
+
+        Args:
+            batch_size: Actual batch size.
+            max_batch_size: Maximum allowed batch size (None = no limit).
+
+        Raises:
+            BatchSizeExceededError: If batch size exceeds maximum.
+        """
+        if max_batch_size and batch_size > max_batch_size:
+            raise BatchSizeExceededError(batch_size, max_batch_size)
+
+    def _build_bulk_result(
+        self,
+        operation_key: str,
+        count: int,
+        data: list[dict[str, Any]] | list[int],
+        errors: list[BulkOperationError],
+        data_key: str = BulkResponseKey.DATA,
+    ) -> dict[str, Any]:
+        """Build standardized bulk operation result.
+
+        Args:
+            operation_key: Result key (e.g., "created", "updated", "deleted").
+            count: Number of successful operations.
+            data: List of data items or IDs.
+            errors: List of errors that occurred.
+            data_key: Key for data in result (default: "data", or "ids" for delete).
+
+        Returns:
+            Standardized result dictionary.
+        """
+        result = {operation_key: count, data_key: data}
+        if errors:
+            result[BulkResponseKey.ERRORS] = [
+                {"index": e.index, "item": e.item, "error": e.error} for e in errors
+            ]
+        return result
+
+    def _check_duplicate_id(self, model_name: str, instance_id: int) -> None:
+        """Check if instance ID already exists in model.
+
+        Args:
+            model_name: Name of the model.
+            instance_id: ID to check.
+
+        Raises:
+            DuplicateInstanceError: If instance with ID already exists.
+        """
+        if instance_id in self._data[model_name]:
+            raise DuplicateInstanceError(model_name, instance_id)
+
+    def _validate_id_present(self, data: dict[str, Any]) -> None:
+        """Validate that primary key field is present in data.
+
+        Args:
+            data: Dictionary to validate.
+
+        Raises:
+            ValueError: If primary key field is missing.
+        """
+        if PRIMARY_KEY_FIELD not in data:
+            raise ValueError(f"Missing required field '{PRIMARY_KEY_FIELD}' for update")
+
+    def _check_instance_exists(self, model_name: str, instance_id: int) -> None:
+        """Check if instance exists in model.
+
+        Args:
+            model_name: Name of the model.
+            instance_id: ID to check.
+
+        Raises:
+            InstanceNotFoundError: If instance with ID does not exist.
+        """
+        if instance_id not in self._data[model_name]:
+            raise InstanceNotFoundError(model_name, instance_id)

--- a/mock_api/core/types.py
+++ b/mock_api/core/types.py
@@ -179,3 +179,23 @@ class SortSpec:
 
     field: str
     direction: str
+
+
+# =============================================================================
+# BULK OPERATION TYPES
+# =============================================================================
+
+
+@dataclass
+class BulkOperationError:
+    """Error details for a failed bulk operation item.
+
+    Attributes:
+        index: Index of the failed item in the original batch.
+        item: The data that failed to process.
+        error: Error message describing the failure.
+    """
+
+    index: int
+    item: dict[str, Any]
+    error: str

--- a/tests/benchmarks/test_router_benchmarks.py
+++ b/tests/benchmarks/test_router_benchmarks.py
@@ -84,7 +84,7 @@ def test_route_generation_single_model(
 ) -> None:
     """Benchmark route generation for single simple model.
 
-    Performance target: < 30ms for 1 model (5 routes)
+    Performance target: < 30ms for 1 model (8 routes)
     Tests per-model route generation overhead.
     """
     parser = SchemaParser()
@@ -96,7 +96,8 @@ def test_route_generation_single_model(
     def generate_single() -> None:
         router_gen = RouterGenerator(schemas=contact_schema, store=store)
         router = router_gen.generate_routes()
-        assert len(router.routes) == 5  # list, create, read, update, delete
+        # 5 CRUD + 3 bulk operations
+        assert len(router.routes) == 8
 
     benchmark(generate_single)
 
@@ -129,7 +130,7 @@ def test_router_scaling_small(
     def generate_small() -> None:
         router_gen = RouterGenerator(schemas=subset_schemas, store=store)
         router = router_gen.generate_routes()
-        assert len(router.routes) == 15  # 3 models * 5 routes
+        assert len(router.routes) == 24  # 3 models * 8 routes
 
     benchmark(generate_small)
 
@@ -160,7 +161,7 @@ def test_router_scaling_medium(
     def generate_medium() -> None:
         router_gen = RouterGenerator(schemas=subset_schemas, store=store)
         router = router_gen.generate_routes()
-        assert len(router.routes) == 30  # 6 models * 5 routes
+        assert len(router.routes) == 48  # 6 models * 8 routes
 
     benchmark(generate_medium)
 

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -108,13 +108,14 @@ def test_generate_routes_returns_router(router_generator: RouterGenerator) -> No
 def test_generate_routes_creates_crud_endpoints(
     router_generator: RouterGenerator,
 ) -> None:
-    """Test that 5 CRUD routes are created per model."""
+    """Test that 8 routes are created per model (5 CRUD + 3 bulk)."""
     router = router_generator.generate_routes()
 
-    # Each model gets 5 routes: LIST, CREATE, READ, UPDATE, DELETE
-    # We have multiple models in the fixtures
+    # Each model gets 8 routes:
+    # - 5 CRUD: LIST, CREATE, READ, UPDATE, DELETE
+    # - 3 BULK: BULK_CREATE, BULK_UPDATE, BULK_DELETE
     total_models = len(router_generator.schemas)
-    expected_routes = total_models * 5
+    expected_routes = total_models * 8
 
     assert len(router.routes) == expected_routes
 

--- a/tests/test_router_bulk.py
+++ b/tests/test_router_bulk.py
@@ -1,0 +1,525 @@
+"""Tests for bulk operation API endpoints."""
+
+from __future__ import annotations
+
+# =============================================================================
+# IMPORTS
+# =============================================================================
+# Standard library
+from pathlib import Path
+
+# Third-party
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+# Project/Local
+from mock_api.core.config import Config
+from mock_api.core.constants import PRIMARY_KEY_FIELD, BulkResponseKey, HTTPStatus
+from mock_api.core.parser import SchemaParser
+from mock_api.core.router import RouterGenerator
+from mock_api.core.store import DataStore
+from mock_api.core.types import ModelSchema
+
+# =============================================================================
+# FIXTURES
+# =============================================================================
+
+
+@pytest.fixture
+def parser() -> SchemaParser:
+    """Create a SchemaParser instance."""
+    return SchemaParser()
+
+
+@pytest.fixture
+def router_models_file() -> str:
+    """Path to router test models fixture file."""
+    return str(Path(__file__).parent / "fixtures" / "generator_models.py")
+
+
+@pytest.fixture
+def schemas(parser: SchemaParser, router_models_file: str) -> dict[str, ModelSchema]:
+    """Parse all test schemas."""
+    return parser.parse_file(router_models_file)
+
+
+@pytest.fixture
+def store() -> DataStore:
+    """Create a fresh data store instance."""
+    return DataStore()
+
+
+@pytest.fixture
+def config() -> Config:
+    """Create a config instance with default bulk operations settings."""
+    return Config()
+
+
+@pytest.fixture
+def router_generator(
+    schemas: dict[str, ModelSchema], store: DataStore, config: Config
+) -> RouterGenerator:
+    """Create a RouterGenerator instance."""
+    return RouterGenerator(schemas, store, config=config)
+
+
+@pytest.fixture
+def app(router_generator: RouterGenerator) -> FastAPI:
+    """Create FastAPI app with generated routes."""
+    app = FastAPI()
+    router = router_generator.generate_routes()
+    app.include_router(router)
+    return app
+
+
+@pytest.fixture
+def client(app: FastAPI) -> TestClient:
+    """Create TestClient for API testing."""
+    return TestClient(app)
+
+
+# =============================================================================
+# TESTS: Bulk Create Endpoint
+# =============================================================================
+
+
+def test_bulk_create_success(client: TestClient) -> None:
+    """Test bulk create endpoint with valid data."""
+    data = {
+        "data": [
+            {
+                "name": "Alice",
+                "email": "alice@example.com",
+                "phone": "555-1111",
+                "username": "alice",
+                "first_name": "Alice",
+                "last_name": "Smith",
+            },
+            {
+                "name": "Bob",
+                "email": "bob@example.com",
+                "phone": "555-2222",
+                "username": "bob",
+                "first_name": "Bob",
+                "last_name": "Jones",
+            },
+        ]
+    }
+
+    response = client.post("/api/v1/contacts/bulk", json=data)
+
+    assert response.status_code == HTTPStatus.CREATED
+    result = response.json()
+    assert result[BulkResponseKey.CREATED] == 2
+    assert len(result[BulkResponseKey.DATA]) == 2
+    assert BulkResponseKey.ERRORS not in result
+
+
+def test_bulk_create_empty_array(client: TestClient) -> None:
+    """Test bulk create with empty array."""
+    response = client.post("/api/v1/contacts/bulk", json={"data": []})
+
+    assert response.status_code == HTTPStatus.CREATED
+    result = response.json()
+    assert result[BulkResponseKey.CREATED] == 0
+
+
+def test_bulk_create_missing_data_field(client: TestClient) -> None:
+    """Test bulk create without data field."""
+    response = client.post("/api/v1/contacts/bulk", json={})
+
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+    assert "data" in response.json()["detail"].lower()
+
+
+def test_bulk_create_validation_error(client: TestClient) -> None:
+    """Test bulk create with invalid item."""
+    data = {
+        "data": [
+            {
+                "name": "Alice",
+                # Missing required fields: email, phone, username, first_name, last_name
+            }
+        ]
+    }
+
+    response = client.post("/api/v1/contacts/bulk", json=data)
+
+    assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+    detail = response.json()["detail"]
+    assert "Validation failed" in detail["message"]
+    assert detail["errors"] is not None
+
+
+def test_bulk_create_exceeds_batch_size(client: TestClient, config: Config) -> None:
+    """Test bulk create exceeding max batch size."""
+    max_size = config.bulk_operations.max_batch_size
+    data = {
+        "data": [
+            {
+                "name": f"User{i}",
+                "email": f"user{i}@example.com",
+                "phone": f"555-{i:04d}",
+                "username": f"user{i}",
+                "first_name": "User",
+                "last_name": str(i),
+            }
+            for i in range(max_size + 1)
+        ]
+    }
+
+    response = client.post("/api/v1/contacts/bulk", json=data)
+
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+    assert "exceeds maximum" in response.json()["detail"]
+
+
+# =============================================================================
+# TESTS: Bulk Update Endpoint
+# =============================================================================
+
+
+def test_bulk_update_success(client: TestClient, store: DataStore) -> None:
+    """Test bulk update endpoint with valid data."""
+    # Create initial data
+    store.create(
+        "Contact",
+        {
+            "name": "Alice",
+            "email": "alice@example.com",
+            "phone": "555-1111",
+            "username": "alice",
+            "first_name": "Alice",
+            "last_name": "Smith",
+        },
+    )
+    store.create(
+        "Contact",
+        {
+            "name": "Bob",
+            "email": "bob@example.com",
+            "phone": "555-2222",
+            "username": "bob",
+            "first_name": "Bob",
+            "last_name": "Jones",
+        },
+    )
+
+    # Update via bulk endpoint (need all required fields for Contact model)
+    data = {
+        "data": [
+            {
+                PRIMARY_KEY_FIELD: 1,
+                "name": "Alice Updated",
+                "email": "alice@example.com",
+                "phone": "555-1111",
+                "username": "alice",
+                "first_name": "Alice",
+                "last_name": "Smith",
+            },
+            {
+                PRIMARY_KEY_FIELD: 2,
+                "name": "Bob Updated",
+                "email": "bob@example.com",
+                "phone": "555-2222",
+                "username": "bob",
+                "first_name": "Bob",
+                "last_name": "Jones",
+            },
+        ]
+    }
+
+    response = client.put("/api/v1/contacts/bulk", json=data)
+
+    assert response.status_code == HTTPStatus.OK
+    result = response.json()
+    assert result[BulkResponseKey.UPDATED] == 2
+    assert len(result[BulkResponseKey.DATA]) == 2
+
+    # Verify updates
+    get_response = client.get("/api/v1/contacts/1")
+    assert get_response.json()["name"] == "Alice Updated"
+
+
+def test_bulk_update_empty_array(client: TestClient) -> None:
+    """Test bulk update with empty array."""
+    response = client.put("/api/v1/contacts/bulk", json={"data": []})
+
+    assert response.status_code == HTTPStatus.OK
+    result = response.json()
+    assert result[BulkResponseKey.UPDATED] == 0
+
+
+def test_bulk_update_missing_id(client: TestClient) -> None:
+    """Test bulk update with missing ID field."""
+    data = {"data": [{"name": "Missing ID"}]}
+
+    response = client.put("/api/v1/contacts/bulk", json=data)
+
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+    assert "id" in response.json()["detail"].lower()
+
+
+def test_bulk_update_not_found(client: TestClient, store: DataStore) -> None:
+    """Test bulk update with non-existent ID."""
+    store.create(
+        "Contact",
+        {
+            "name": "Alice",
+            "email": "alice@example.com",
+            "phone": "555-1111",
+            "username": "alice",
+            "first_name": "Alice",
+            "last_name": "Smith",
+        },
+    )
+
+    data = {
+        "data": [
+            {
+                PRIMARY_KEY_FIELD: 1,
+                "name": "Alice Updated",
+                "email": "alice@example.com",
+                "phone": "555-1111",
+                "username": "alice",
+                "first_name": "Alice",
+                "last_name": "Smith",
+            },
+            {
+                PRIMARY_KEY_FIELD: 999,
+                "name": "Not Found",
+                "email": "notfound@example.com",
+                "phone": "555-9999",
+                "username": "notfound",
+                "first_name": "Not",
+                "last_name": "Found",
+            },
+        ]
+    }
+
+    response = client.put("/api/v1/contacts/bulk", json=data)
+
+    assert response.status_code == HTTPStatus.NOT_FOUND
+
+
+def test_bulk_update_validation_error(client: TestClient, store: DataStore) -> None:
+    """Test bulk update with invalid data."""
+    store.create(
+        "Contact",
+        {
+            "name": "Alice",
+            "email": "alice@example.com",
+            "phone": "555-1111",
+            "username": "alice",
+            "first_name": "Alice",
+            "last_name": "Smith",
+        },
+    )
+
+    data = {
+        "data": [
+            {
+                PRIMARY_KEY_FIELD: 1,
+                # Missing required fields to pass validation
+                "invalid_field": "not_allowed",
+            }
+        ]
+    }
+
+    response = client.put("/api/v1/contacts/bulk", json=data)
+
+    assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+
+def test_bulk_update_exceeds_batch_size(client: TestClient, config: Config) -> None:
+    """Test bulk update exceeding max batch size."""
+    max_size = config.bulk_operations.max_batch_size
+    data = {
+        "data": [
+            {
+                PRIMARY_KEY_FIELD: i,
+                "name": f"User{i}",
+                "email": f"user{i}@example.com",
+                "phone": f"555-{i:04d}",
+                "username": f"user{i}",
+                "first_name": "User",
+                "last_name": str(i),
+            }
+            for i in range(1, max_size + 2)
+        ]
+    }
+
+    response = client.put("/api/v1/contacts/bulk", json=data)
+
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+    assert "exceeds maximum" in response.json()["detail"]
+
+
+# =============================================================================
+# TESTS: Bulk Delete Endpoint
+# =============================================================================
+
+
+def test_bulk_delete_success(client: TestClient, store: DataStore) -> None:
+    """Test bulk delete endpoint with valid IDs."""
+    # Create test data
+    for i in range(5):
+        store.create(
+            "Contact",
+            {
+                "name": f"User{i}",
+                "email": f"user{i}@example.com",
+                "phone": f"555-{i:04d}",
+                "username": f"user{i}",
+                "first_name": "User",
+                "last_name": str(i),
+            },
+        )
+
+    response = client.delete("/api/v1/contacts/bulk?ids=1,2,3")
+
+    assert response.status_code == HTTPStatus.OK
+    result = response.json()
+    assert result[BulkResponseKey.DELETED] == 3
+    assert result[BulkResponseKey.IDS] == [1, 2, 3]
+    assert BulkResponseKey.ERRORS not in result
+
+    # Verify deletions
+    assert store.count("Contact") == 2
+
+
+def test_bulk_delete_single_id(client: TestClient, store: DataStore) -> None:
+    """Test bulk delete with single ID."""
+    store.create("Contact", {"name": "Alice", "email": "alice@example.com"})
+
+    response = client.delete("/api/v1/contacts/bulk?ids=1")
+
+    assert response.status_code == HTTPStatus.OK
+    result = response.json()
+    assert result[BulkResponseKey.DELETED] == 1
+
+
+def test_bulk_delete_missing_ids_param(client: TestClient) -> None:
+    """Test bulk delete without IDs parameter."""
+    response = client.delete("/api/v1/contacts/bulk")
+
+    assert response.status_code == 422  # FastAPI validation error
+
+
+def test_bulk_delete_invalid_id_format(client: TestClient) -> None:
+    """Test bulk delete with invalid ID format."""
+    response = client.delete("/api/v1/contacts/bulk?ids=1,abc,3")
+
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+    assert "Invalid ID format" in response.json()["detail"]
+
+
+def test_bulk_delete_not_found(client: TestClient, store: DataStore) -> None:
+    """Test bulk delete with non-existent IDs."""
+    store.create("Contact", {"name": "Alice", "email": "alice@example.com"})
+
+    response = client.delete("/api/v1/contacts/bulk?ids=1,999")
+
+    assert response.status_code == HTTPStatus.NOT_FOUND
+
+
+def test_bulk_delete_exceeds_batch_size(client: TestClient, config: Config) -> None:
+    """Test bulk delete exceeding max batch size."""
+    max_size = config.bulk_operations.max_batch_size
+    ids = ",".join(str(i) for i in range(1, max_size + 2))
+
+    response = client.delete(f"/api/v1/contacts/bulk?ids={ids}")
+
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+    assert "exceeds maximum" in response.json()["detail"]
+
+
+def test_bulk_delete_with_spaces_in_ids(client: TestClient, store: DataStore) -> None:
+    """Test bulk delete handles spaces in ID list."""
+    for i in range(3):
+        store.create("Contact", {"name": f"User{i}", "email": f"user{i}@example.com"})
+
+    # IDs with spaces
+    response = client.delete("/api/v1/contacts/bulk?ids=1, 2, 3")
+
+    assert response.status_code == HTTPStatus.OK
+    result = response.json()
+    assert result[BulkResponseKey.DELETED] == 3
+
+
+# =============================================================================
+# TESTS: Integration with Regular CRUD
+# =============================================================================
+
+
+def test_bulk_create_then_regular_read(client: TestClient, store: DataStore) -> None:
+    """Test that bulk created items can be read via regular endpoint."""
+    data = {
+        "data": [
+            {
+                "name": "Alice",
+                "email": "alice@example.com",
+                "phone": "555-1111",
+                "username": "alice",
+                "first_name": "Alice",
+                "last_name": "Smith",
+            }
+        ]
+    }
+
+    create_response = client.post("/api/v1/contacts/bulk", json=data)
+    assert create_response.status_code == HTTPStatus.CREATED
+
+    # Read via regular endpoint
+    read_response = client.get("/api/v1/contacts/1")
+    assert read_response.status_code == HTTPStatus.OK
+    assert read_response.json()["name"] == "Alice"
+
+
+def test_regular_create_then_bulk_update(client: TestClient, store: DataStore) -> None:
+    """Test that regularly created items can be bulk updated."""
+    # Create via regular endpoint
+    create_data = {
+        "name": "Alice",
+        "email": "alice@example.com",
+        "phone": "555-1111",
+        "username": "alice",
+        "first_name": "Alice",
+        "last_name": "Smith",
+    }
+    client.post("/api/v1/contacts", json=create_data)
+
+    # Update via bulk endpoint (need all required fields)
+    update_data = {
+        "data": [
+            {
+                PRIMARY_KEY_FIELD: 1,
+                "name": "Alice Updated",
+                "email": "alice@example.com",
+                "phone": "555-1111",
+                "username": "alice",
+                "first_name": "Alice",
+                "last_name": "Smith",
+            }
+        ]
+    }
+    update_response = client.put("/api/v1/contacts/bulk", json=update_data)
+
+    assert update_response.status_code == HTTPStatus.OK
+    result = update_response.json()
+    assert result[BulkResponseKey.UPDATED] == 1
+
+
+def test_bulk_operations_respect_model_schema(client: TestClient) -> None:
+    """Test that bulk operations validate against model schema."""
+    # Try to create with missing required fields
+    data = {
+        "data": [
+            {"name": "Missing Fields"}  # Missing required email, phone, etc
+        ]
+    }
+
+    response = client.post("/api/v1/contacts/bulk", json=data)
+
+    assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -106,9 +106,9 @@ def test_create_app_includes_routes(server: Server) -> None:
     """Test create_app includes all generated routes."""
     app = server.create_app()
 
-    # Each model gets 5 routes
+    # Each model gets 8 routes (5 CRUD + 3 bulk operations)
     total_models = len(server.schemas)
-    expected_routes = total_models * 5
+    expected_routes = total_models * 8
 
     # Count only API CRUD routes (exclude docs, openapi, etc)
     api_routes = [

--- a/tests/test_store_bulk.py
+++ b/tests/test_store_bulk.py
@@ -1,0 +1,355 @@
+"""Tests for DataStore bulk operations."""
+
+from __future__ import annotations
+
+# =============================================================================
+# IMPORTS
+# =============================================================================
+# Standard library
+from typing import Any
+
+# Third-party
+import pytest
+
+# Project/Local
+from mock_api.core.constants import PRIMARY_KEY_FIELD, BulkResponseKey
+from mock_api.core.exceptions import (
+    BatchSizeExceededError,
+    DuplicateInstanceError,
+    InstanceNotFoundError,
+)
+from mock_api.core.store import DataStore
+
+# =============================================================================
+# FIXTURES
+# =============================================================================
+
+
+@pytest.fixture
+def store() -> DataStore:
+    """Create a fresh DataStore instance."""
+    return DataStore()
+
+
+@pytest.fixture
+def sample_users() -> list[dict[str, Any]]:
+    """Sample user data for testing."""
+    return [
+        {"name": "Alice", "email": "alice@example.com"},
+        {"name": "Bob", "email": "bob@example.com"},
+        {"name": "Charlie", "email": "charlie@example.com"},
+    ]
+
+
+# =============================================================================
+# TESTS: Bulk Create
+# =============================================================================
+
+
+def test_bulk_create_success(
+    store: DataStore, sample_users: list[dict[str, Any]]
+) -> None:
+    """Test bulk create with all items succeeding."""
+    result = store.bulk_create("User", sample_users)
+
+    assert result[BulkResponseKey.CREATED] == 3
+    assert len(result[BulkResponseKey.DATA]) == 3
+    assert BulkResponseKey.ERRORS not in result
+
+    # Verify all items were created
+    for idx, item in enumerate(result[BulkResponseKey.DATA]):
+        assert item[PRIMARY_KEY_FIELD] == idx + 1
+        assert item["name"] == sample_users[idx]["name"]
+        assert item["email"] == sample_users[idx]["email"]
+
+
+def test_bulk_create_empty_list(store: DataStore) -> None:
+    """Test bulk create with empty list."""
+    result = store.bulk_create("User", [])
+
+    assert result[BulkResponseKey.CREATED] == 0
+    assert result[BulkResponseKey.DATA] == []
+    assert BulkResponseKey.ERRORS not in result
+
+
+def test_bulk_create_auto_assigns_ids(store: DataStore) -> None:
+    """Test that bulk create auto-assigns sequential IDs."""
+    data = [{"name": f"User{i}"} for i in range(5)]
+    result = store.bulk_create("User", data)
+
+    created_ids = [item[PRIMARY_KEY_FIELD] for item in result[BulkResponseKey.DATA]]
+    assert created_ids == [1, 2, 3, 4, 5]
+
+
+def test_bulk_create_with_duplicate_id_rollback(store: DataStore) -> None:
+    """Test bulk create rolls back on duplicate ID when not partial."""
+    # Create initial item
+    store.create("User", {"name": "Existing"})
+
+    # Try to bulk create with duplicate ID
+    data = [
+        {"name": "Alice"},
+        {PRIMARY_KEY_FIELD: 1, "name": "Duplicate"},  # Duplicate ID
+        {"name": "Bob"},
+    ]
+
+    with pytest.raises(DuplicateInstanceError):
+        store.bulk_create("User", data)
+
+    # Verify rollback - only original item exists
+    assert store.count("User") == 1
+
+
+def test_bulk_create_partial_mode_continues_on_error(store: DataStore) -> None:
+    """Test bulk create in partial mode continues on errors."""
+    # Create initial item
+    store.create("User", {"name": "Existing"})
+
+    data = [
+        {"name": "Alice"},
+        {PRIMARY_KEY_FIELD: 1, "name": "Duplicate"},  # Will fail
+        {"name": "Bob"},
+    ]
+
+    result = store.bulk_create("User", data, allow_partial=True)
+
+    assert result[BulkResponseKey.CREATED] == 2
+    assert len(result[BulkResponseKey.DATA]) == 2
+    assert len(result[BulkResponseKey.ERRORS]) == 1
+    assert result[BulkResponseKey.ERRORS][0]["index"] == 1
+
+
+def test_bulk_create_exceeds_batch_size(store: DataStore) -> None:
+    """Test bulk create raises error when batch size exceeded."""
+    data = [{"name": f"User{i}"} for i in range(10)]
+
+    with pytest.raises(BatchSizeExceededError):
+        store.bulk_create("User", data, max_batch_size=5)
+
+
+# =============================================================================
+# TESTS: Bulk Update
+# =============================================================================
+
+
+def test_bulk_update_success(store: DataStore) -> None:
+    """Test bulk update with all items succeeding."""
+    # Create initial items
+    store.create("User", {"name": "Alice", "email": "alice@example.com"})
+    store.create("User", {"name": "Bob", "email": "bob@example.com"})
+
+    # Update them
+    updates = [
+        {PRIMARY_KEY_FIELD: 1, "name": "Alice Updated"},
+        {PRIMARY_KEY_FIELD: 2, "name": "Bob Updated"},
+    ]
+
+    result = store.bulk_update("User", updates)
+
+    assert result[BulkResponseKey.UPDATED] == 2
+    assert len(result[BulkResponseKey.DATA]) == 2
+    assert BulkResponseKey.ERRORS not in result
+
+    # Verify updates
+    user1 = store.read("User", 1)
+    user2 = store.read("User", 2)
+    assert user1 is not None
+    assert user2 is not None
+    assert user1["name"] == "Alice Updated"
+    assert user2["name"] == "Bob Updated"
+
+
+def test_bulk_update_empty_list(store: DataStore) -> None:
+    """Test bulk update with empty list."""
+    result = store.bulk_update("User", [])
+
+    assert result[BulkResponseKey.UPDATED] == 0
+    assert result[BulkResponseKey.DATA] == []
+
+
+def test_bulk_update_missing_id_rollback(store: DataStore) -> None:
+    """Test bulk update rolls back when ID missing in non-partial mode."""
+    store.create("User", {"name": "Alice"})
+    store.create("User", {"name": "Bob"})
+
+    updates = [
+        {PRIMARY_KEY_FIELD: 1, "name": "Alice Updated"},
+        {"name": "Missing ID"},  # Missing ID
+    ]
+
+    with pytest.raises(ValueError):
+        store.bulk_update("User", updates)
+
+    # Verify rollback
+    user1 = store.read("User", 1)
+    assert user1 is not None
+    assert user1["name"] == "Alice"  # Not updated
+
+
+def test_bulk_update_not_found_rollback(store: DataStore) -> None:
+    """Test bulk update rolls back on not found error."""
+    store.create("User", {"name": "Alice"})
+
+    updates = [
+        {PRIMARY_KEY_FIELD: 1, "name": "Alice Updated"},
+        {PRIMARY_KEY_FIELD: 999, "name": "Not Found"},  # Doesn't exist
+    ]
+
+    with pytest.raises(InstanceNotFoundError):
+        store.bulk_update("User", updates)
+
+    # Verify rollback
+    user1 = store.read("User", 1)
+    assert user1 is not None
+    assert user1["name"] == "Alice"  # Not updated
+
+
+def test_bulk_update_partial_mode_continues_on_error(store: DataStore) -> None:
+    """Test bulk update in partial mode continues on errors."""
+    store.create("User", {"name": "Alice"})
+    store.create("User", {"name": "Bob"})
+
+    updates = [
+        {PRIMARY_KEY_FIELD: 1, "name": "Alice Updated"},
+        {PRIMARY_KEY_FIELD: 999, "name": "Not Found"},  # Will fail
+        {PRIMARY_KEY_FIELD: 2, "name": "Bob Updated"},
+    ]
+
+    result = store.bulk_update("User", updates, allow_partial=True)
+
+    assert result[BulkResponseKey.UPDATED] == 2
+    assert len(result[BulkResponseKey.ERRORS]) == 1
+    assert result[BulkResponseKey.ERRORS][0]["index"] == 1
+
+    # Verify successful updates
+    user1 = store.read("User", 1)
+    user2 = store.read("User", 2)
+    assert user1 is not None
+    assert user2 is not None
+    assert user1["name"] == "Alice Updated"
+    assert user2["name"] == "Bob Updated"
+
+
+def test_bulk_update_model_not_found(store: DataStore) -> None:
+    """Test bulk update with non-existent model."""
+    updates = [{PRIMARY_KEY_FIELD: 1, "name": "Test"}]
+
+    with pytest.raises(InstanceNotFoundError):
+        store.bulk_update("NonExistent", updates)
+
+
+def test_bulk_update_exceeds_batch_size(store: DataStore) -> None:
+    """Test bulk update raises error when batch size exceeded."""
+    updates = [{PRIMARY_KEY_FIELD: i, "name": f"User{i}"} for i in range(10)]
+
+    with pytest.raises(BatchSizeExceededError):
+        store.bulk_update("User", updates, max_batch_size=5)
+
+
+# =============================================================================
+# TESTS: Bulk Delete
+# =============================================================================
+
+
+def test_bulk_delete_success(store: DataStore) -> None:
+    """Test bulk delete with all items succeeding."""
+    # Create items
+    store.create("User", {"name": "Alice"})
+    store.create("User", {"name": "Bob"})
+    store.create("User", {"name": "Charlie"})
+
+    result = store.bulk_delete("User", [1, 2, 3])
+
+    assert result[BulkResponseKey.DELETED] == 3
+    assert result[BulkResponseKey.IDS] == [1, 2, 3]
+    assert BulkResponseKey.ERRORS not in result
+
+    # Verify deletion
+    assert store.count("User") == 0
+
+
+def test_bulk_delete_empty_list(store: DataStore) -> None:
+    """Test bulk delete with empty list."""
+    result = store.bulk_delete("User", [])
+
+    assert result[BulkResponseKey.DELETED] == 0
+    assert result[BulkResponseKey.IDS] == []
+
+
+def test_bulk_delete_not_found_rollback(store: DataStore) -> None:
+    """Test bulk delete rolls back on not found error."""
+    store.create("User", {"name": "Alice"})
+    store.create("User", {"name": "Bob"})
+
+    with pytest.raises(InstanceNotFoundError):
+        store.bulk_delete("User", [1, 999, 2])  # 999 doesn't exist
+
+    # Verify rollback - all items still exist
+    assert store.count("User") == 2
+
+
+def test_bulk_delete_partial_mode_continues_on_error(store: DataStore) -> None:
+    """Test bulk delete in partial mode continues on errors."""
+    store.create("User", {"name": "Alice"})
+    store.create("User", {"name": "Bob"})
+    store.create("User", {"name": "Charlie"})
+
+    result = store.bulk_delete("User", [1, 999, 3], allow_partial=True)
+
+    assert result[BulkResponseKey.DELETED] == 2
+    assert result[BulkResponseKey.IDS] == [1, 3]
+    assert len(result[BulkResponseKey.ERRORS]) == 1
+    assert result[BulkResponseKey.ERRORS][0]["index"] == 1
+
+    # Verify successful deletions and remaining item
+    assert store.count("User") == 1
+    user2 = store.read("User", 2)
+    assert user2 is not None
+    assert user2["name"] == "Bob"
+
+
+def test_bulk_delete_model_not_found(store: DataStore) -> None:
+    """Test bulk delete with non-existent model."""
+    with pytest.raises(InstanceNotFoundError):
+        store.bulk_delete("NonExistent", [1, 2, 3])
+
+
+def test_bulk_delete_exceeds_batch_size(store: DataStore) -> None:
+    """Test bulk delete raises error when batch size exceeded."""
+    with pytest.raises(BatchSizeExceededError):
+        store.bulk_delete("User", list(range(1, 11)), max_batch_size=5)
+
+
+# =============================================================================
+# TESTS: Thread Safety
+# =============================================================================
+
+
+def test_bulk_operations_are_atomic(store: DataStore) -> None:
+    """Test that bulk operations are atomic within their scope."""
+    # Create initial data
+    for i in range(5):
+        store.create("User", {"name": f"User{i}"})
+
+    # Attempt bulk update with error - should rollback all
+    updates = [{PRIMARY_KEY_FIELD: i, "name": f"Updated{i}"} for i in range(1, 6)]
+    updates.append({PRIMARY_KEY_FIELD: 999, "name": "Invalid"})  # Will fail
+
+    with pytest.raises(InstanceNotFoundError):
+        store.bulk_update("User", updates)
+
+    # Verify no updates were applied
+    for i in range(1, 6):
+        user = store.read("User", i)
+        assert user is not None
+        assert user["name"] == f"User{i - 1}"  # Original name
+
+
+def test_bulk_create_increments_counter_correctly(store: DataStore) -> None:
+    """Test that bulk create increments ID counter correctly."""
+    # Bulk create 3 items
+    store.bulk_create("User", [{"name": f"User{i}"} for i in range(3)])
+
+    # Create single item - should get ID 4
+    result = store.create("User", {"name": "User4"})
+    assert result[PRIMARY_KEY_FIELD] == 4


### PR DESCRIPTION
## Summary
Implements bulk operations feature for issue #19.

**New endpoints per model:**
- `POST /models/bulk` - Bulk create with `{data: [...]}`
- `PUT /models/bulk` - Bulk update with `{data: [{id: 1, ...}, ...]}`
- `DELETE /models/bulk?ids=1,2,3` - Bulk delete

**Features:**
- All-or-nothing transaction semantics by default
- Configurable batch size limits (default: 1000, max: 10000)
- Optional partial mode for continuing on errors
- Detailed response with counts and error reporting
- Per-item Pydantic validation

**Configuration:**
```yaml
bulk_operations:
  max_batch_size: 1000
  allow_partial: false
```

**Testing:**
- 21 new unit tests for DataStore bulk methods
- 21 new integration tests for API endpoints
- All 357 tests passing
- Coverage maintained at 90%+

Closes #19